### PR TITLE
+ Timestamp, Transactions, USD Value columns be moved closer to the H…

### DIFF
--- a/app/components/BlockList/index.jsx
+++ b/app/components/BlockList/index.jsx
@@ -15,10 +15,14 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { Link } from 'react-router-dom';
 
-import { FormattedUnixDateTime, Messages as datetimeMessages } from 'components/FormattedDateTime';
+import {
+  FormattedUnixDateTime,
+  Messages as datetimeMessages,
+} from 'components/FormattedDateTime';
 import ColoredHash from 'components/ColoredHash';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import InformationIcon from 'react-icons/lib/io/informatcircled';
+import getLogo from 'utils/getLogo';
 import messages from './messages';
 
 const StyledTR = styled.tr`
@@ -29,154 +33,202 @@ const StyledTable = styled(Table)`
     font-weight: normal;
   }
 `;
-
+const IMGLogo = styled.img`
+  display: inline;
+  width: 2rem;
+  height: 2rem;
+  margin-right: 1rem;
+`;
 class BlockList extends React.PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
     const getItemKey = (item, idx) => item.timestamp.toString().concat(idx);
+
+    const invalidTxTooltipMsg = (block, txsAcumulator) =>
+      block.omni_tx_count - txsAcumulator ? (
+        <span>Invalid: {block.omni_tx_count - txsAcumulator}</span>
+      ) : null;
+
     const getOmniTxProps = block => {
       let txsAcumulator = 0;
-      return (
-        <div style={{ padding: '0.5rem 1rem' }} className="text-left">
-          <strong>Property:Count</strong>
-          <br/>
-          {Object.keys(block.value.details).map((prop, idx) => {
-            const txsCount = block.value.details[prop].tx_count;
-            txsAcumulator += txsCount;
-            return (
-              <span key={`block${txsCount}${idx}`}>
-                #{prop}: {txsCount}
-                <br/>
-              </span>
-            );
-          })}
-          <span>Invalid TXs: {block.omni_tx_count - txsAcumulator}</span>
-        </div>
-      );
-    };
-    const getOmniTxValues = block => (
-      <div style={{ padding: '0.5rem 1rem' }} className="text-left">
-        <strong>Property:Value</strong>
-        <br/>
-        {Object.keys(block.value.details).map((prop, idx) => (
-          <span key={idx}>
-            #{prop}: $<SanitizedFormattedNumber
-            value={block.value.details[prop].value_usd_rounded}
-          />
-            <br/>
-          </span>
-        ))}
-      </div>
-    );
+      let content;
+      if (!block.omni_tx_count) {
+        content = (
+          <div style={{ padding: '0.5rem 1rem' }} className="text-left">
+            <span>
+              None
+              <br />
+            </span>
+          </div>
+        );
+      } else {
+        content = (
+          <div style={{ padding: '0.5rem 1rem' }} className="text-left">
+            {!block.value.error &&
+              Object.keys(block.value.details).map((prop, idx) => {
+                const txsCount = block.value.details[prop].tx_count;
+                txsAcumulator += txsCount;
+                return (
+                  <span key={`block${txsCount}${idx}`}>
+                    #{prop}: {txsCount}
+                    <br />
+                  </span>
+                );
+              })}
+            {invalidTxTooltipMsg(block, txsAcumulator)}
+          </div>
+        );
+      }
 
+      return content;
+    };
+
+    const getOmniTxValues = block => {
+      let content;
+      if (!block.omni_tx_count || block.value.error) {
+        content = (
+          <div style={{ padding: '0.5rem 1rem' }} className="text-left">
+            <span>
+              $0
+              <br />
+            </span>
+          </div>
+        );
+      } else {
+        content = (
+          <div style={{ padding: '0.5rem 1rem' }} className="text-left">
+            {Object.keys(block.value.details).map((prop, idx) => (
+              <span key={`prop${prop}${idx}`}>
+                #{prop}: $<SanitizedFormattedNumber
+                  value={block.value.details[prop].value_usd_rounded}
+                />
+                <br />
+              </span>
+            ))}
+          </div>
+        );
+      }
+      return content;
+    };
+
+    const getOmniTxLogos = block => {
+      const logos = Object.keys(block.value.details).map((prop, idx) => {
+        const logo = getLogo(prop);
+        return (
+          <IMGLogo key={prop}
+          src={logo}
+          alt=""
+        />
+      );
+      });
+      return logos;
+    };
     return (
       <StyledTable responsive striped hover>
         <thead>
-        <tr>
-          <th>
-            <FormattedMessage {...messages.columns.block} />
-          </th>
-          <th className="text-right">
-            <FormattedMessage {...messages.columns.timestamp} />
-            <InformationIcon
-              color="gray"
-              className="ml-1"
-              id="blocktimestamp"
-            />
-            <UncontrolledTooltip
-              placement="right-end"
-              target="blocktimestamp"
-            >
-              <FormattedMessage {...datetimeMessages.utc} />
-            </UncontrolledTooltip>
-          </th>
-          <th className="text-right">
-            <FormattedMessage {...messages.columns.txcount} />
-            <InformationIcon
-              color="gray"
-              className="ml-1"
-              id="blockListTransactionCount"
-            />
-            <UncontrolledTooltip
-              placement="right-end"
-              target="blockListTransactionCount"
-            >
-              <FormattedMessage {...messages.columns.txtooltip} />
-            </UncontrolledTooltip>
-          </th>
-          <th className="text-right">
-            <FormattedMessage {...messages.columns.usdvalue} />
-            <InformationIcon
-              color="gray"
-              className="ml-1"
-              id="blockListUSDValue"
-            />
-            <UncontrolledTooltip
-              placement="right-end"
-              target="blockListUSDValue"
-            >
-              <FormattedMessage {...messages.columns.usdtooltip} />
-            </UncontrolledTooltip>
-          </th>
-          <th className="text-right">
-            <FormattedMessage {...messages.columns.blockhash} />
-          </th>
-        </tr>
+          <tr>
+            <th>
+              <FormattedMessage {...messages.columns.block} />
+            </th>
+            <th className="text-center">
+              <FormattedMessage {...messages.columns.timestamp} />
+              <InformationIcon
+                color="gray"
+                className="ml-1"
+                id="blocktimestamp"
+              />
+              <UncontrolledTooltip
+                placement="right-end"
+                target="blocktimestamp"
+              >
+                <FormattedMessage {...datetimeMessages.utc} />
+              </UncontrolledTooltip>
+            </th>
+            <th className="text-right">
+              <FormattedMessage {...messages.columns.txcount} />
+              <InformationIcon
+                color="gray"
+                className="ml-1"
+                id="blockListTransactionCount"
+              />
+              <UncontrolledTooltip
+                placement="right-end"
+                target="blockListTransactionCount"
+              >
+                <FormattedMessage {...messages.columns.txtooltip} />
+              </UncontrolledTooltip>
+            </th>
+            <th className="text-right">
+              <FormattedMessage {...messages.columns.usdvalue} />
+              <InformationIcon
+                color="gray"
+                className="ml-1"
+                id="blockListUSDValue"
+              />
+              <UncontrolledTooltip
+                placement="right-end"
+                target="blockListUSDValue"
+              >
+                <FormattedMessage {...messages.columns.usdtooltip} />
+              </UncontrolledTooltip>
+            </th>
+            <th className="text-right">
+              <FormattedMessage {...messages.columns.blockhash} />
+            </th>
+          </tr>
         </thead>
         <tbody>
-        {this.props.blocks.map((block, idx) => (
-          <StyledTR
-            key={getItemKey(block, idx)}
-            // onClick={() => this.props.changeRoute(`/block/${block.block}`)}
-          >
-            <td>
-              <Link
-                to={{
-                  pathname: `/block/${block.block}`,
-                  state: { state: this.props.state },
-                }}
-              >
-                {block.block}
-              </Link>
-            </td>
-            <td className="text-right">
-              <FormattedUnixDateTime datetime={block.timestamp}/>
-            </td>
-            <td className="text-right">
-              <span id={`omnitxcount${idx}`}>{block.omni_tx_count}</span>
-              <UncontrolledTooltip
-                placement="top-start"
-                target={`omnitxcount${idx}`}
-                autohide={false}
-              >
-                {getOmniTxProps(block)}
-              </UncontrolledTooltip>
-            </td>
-            <td className="text-right">
+          {this.props.blocks.map((block, idx) => (
+            <StyledTR key={getItemKey(block, idx)}>
+              <td>
+                <Link
+                  to={{
+                    pathname: `/block/${block.block}`,
+                    state: { state: this.props.state },
+                  }}
+                >
+                  {block.block}
+                </Link>
+              </td>
+              <td className="text-center">
+                <FormattedUnixDateTime datetime={block.timestamp} />
+              </td>
+              <td className="text-right">
+                {getOmniTxLogos(block)}
+                <div style={{width:'3rem', display: 'inline-block'}} id={`omnitxcount${idx}`}>{block.omni_tx_count}</div>
+                <UncontrolledTooltip
+                  placement="right-end"
+                  target={`omnitxcount${idx}`}
+                  autohide={false}
+                >
+                  {getOmniTxProps(block)}
+                </UncontrolledTooltip>
+              </td>
+              <td className="text-right">
                 <span id={`totalusd${idx}`}>
                   $&nbsp;
-                  <SanitizedFormattedNumber value={block.value.total_usd}/>
+                  <SanitizedFormattedNumber value={block.value.total_usd} />
                 </span>
-              <UncontrolledTooltip
-                placement="top-start"
-                target={`totalusd${idx}`}
-                autohide={false}
-              >
-                {getOmniTxValues(block)}
-              </UncontrolledTooltip>
-            </td>
-            <td className="text-right">
-              <Link
-                to={{
-                  pathname: `/block/${block.block}`,
-                  state: { state: this.props.state },
-                }}
-              >
-                <ColoredHash hash={block.block_hash}/>
-              </Link>
-            </td>
-          </StyledTR>
-        ))}
+                <UncontrolledTooltip
+                  placement="right-start"
+                  target={`totalusd${idx}`}
+                  autohide={false}
+                >
+                  {getOmniTxValues(block)}
+                </UncontrolledTooltip>
+              </td>
+              <td className="text-right">
+                <Link
+                  to={{
+                    pathname: `/block/${block.block}`,
+                    state: { state: this.props.state },
+                  }}
+                >
+                  <ColoredHash hash={block.block_hash} />
+                </Link>
+              </td>
+            </StyledTR>
+          ))}
         </tbody>
       </StyledTable>
     );

--- a/app/components/BlockList/messages.js
+++ b/app/components/BlockList/messages.js
@@ -33,11 +33,11 @@ export default defineMessages({
     },
     txtooltip: {
       id: 'app.components.BlockList.columns.txtooltip',
-      defaultMessage: 'This represents the number of Omni Protocol Transactions in the block',
+      defaultMessage: 'Omni Protocol Transactions in the block',
     },
     usdtooltip: {
       id: 'app.components.BlockList.columns.usdooltip',
-      defaultMessage: 'The value is rounded to the nearest dollar',
+      defaultMessage: 'Rounded to the nearest dollar',
     },
   },
 });

--- a/app/components/CrowdsaleTransaction/index.jsx
+++ b/app/components/CrowdsaleTransaction/index.jsx
@@ -22,6 +22,7 @@ import { CONFIRMATIONS } from 'containers/Transactions/constants';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import ColoredHash from 'components/ColoredHash';
+import StatusConfirmation from 'components/StatusConfirmation';
 import getLogo from 'utils/getLogo';
 import './transaction.scss';
 
@@ -134,25 +135,15 @@ class CrowdsaleTransaction extends React.PureComponent { // eslint-disable-line 
   }
 
   render() {
-    const isValid = this.props.valid;
+    // const isValid = this.props.valid;
     let statusCSSClass = 'btn btn-primary btn-block font-weight-light w-50';
-    statusCSSClass = (isValid ? `${statusCSSClass} btn-blue` : (this.props.confirmations === 0 ? `${statusCSSClass} btn-warning` : `${statusCSSClass} btn-danger`));
+    statusCSSClass = (this.props.valid ? `${statusCSSClass} btn-blue` : (this.props.confirmations === 0 ? `${statusCSSClass} btn-warning` : `${statusCSSClass} btn-danger`));
 
-    const status = (
-      isValid ?
-        this.props.confirmations < CONFIRMATIONS ?
-          this.props.confirmations === 0 ?
-            'UNCONFIRMED' :
-            this.props.confirmations > 1 ?
-              `${this.props.confirmations} CONFIRMATIONS` :
-              `${this.props.confirmations} CONFIRMATION`
-          :
-          'CONFIRMED'
-        :
-        this.props.confirmations === 0 ?
-          'UNCONFIRMED' :
-          'INVALID'
-    );
+    const status = StatusConfirmation({
+      valid: this.props.valid,
+      confirmations: this.props.confirmations,
+      confirmed: CONFIRMATIONS,
+    });
 
     const tokenLogo = getLogo(this.props.propertyid, this.props);
 
@@ -215,7 +206,7 @@ class CrowdsaleTransaction extends React.PureComponent { // eslint-disable-line 
                     state: { state: this.props.state },
                   }}
                 >
-                  <ColoredHash hash={this.props.txid} />
+                  <ColoredHash hash={this.props.txid}/>
                 </Link>
               </WrapperTx>
               <CopyToClipboard text={this.props.txid} onCopy={this.toggleTxTooltip}>

--- a/app/components/StatusConfirmation/index.jsx
+++ b/app/components/StatusConfirmation/index.jsx
@@ -1,0 +1,42 @@
+/**
+ *
+ * StatusConfirmation
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage, FormattedPlural } from 'react-intl';
+import messages from './messages';
+
+function StatusConfirmation(props) {
+  const pluralizeConfirmations = confirmations =>
+    confirmations > 1
+      ? `${confirmations} CONFIRMATIONS`
+      : `${confirmations} CONFIRMATION`;
+
+  const confirmedUnconfirmed = confirmations =>
+    confirmations === 0
+      ? 'UNCONFIRMED'
+      : pluralizeConfirmations(confirmations);
+
+  const getStatus = (tx) => {
+    if (tx.valid) {
+      return tx.confirmations < tx.confirmed
+        ? confirmedUnconfirmed(tx.confirmations)
+        : 'CONFIRMED';
+    }
+    return tx.confirmations === 0 ? 'UNCONFIRMED' : 'INVALID';
+  };
+
+  const status = getStatus(props);
+  return <span>{status}</span>;
+}
+
+StatusConfirmation.propTypes = {
+  confirmations: PropTypes.number.isRequired,
+  confirmed: PropTypes.number.isRequired,
+  valid: PropTypes.bool.isRequired,
+};
+
+export default StatusConfirmation;

--- a/app/components/StatusConfirmation/messages.js
+++ b/app/components/StatusConfirmation/messages.js
@@ -1,0 +1,32 @@
+/*
+ * StatusConfirmation Messages
+ *
+ * This contains all the text for the StatusConfirmation component.
+ */
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  header: {
+    id: 'app.components.StatusConfirmation.header',
+    defaultMessage: 'This is the StatusConfirmation component !',
+  },
+  confirmations: {
+    id: 'app.components.StatusConfirmation.confirmations',
+    defaultMessage: '{confirmations} CONFIRMATIONS',
+    one: '{confirmations} CONFIRMATION',
+    other: '{confirmations} CONFIRMATIONS',
+    zero: '{confirmations} CONFIRMATIONS',
+  },
+  confirmed: {
+    id: 'app.components.StatusConfirmation.confirmed',
+    defaultMessage: 'CONFIRMED',
+  },
+  unconfirmed: {
+    id: 'app.components.StatusConfirmation.unconfirmed',
+    defaultMessage: 'UNCONFIRMED',
+  },
+  invalid: {
+    id: 'app.components.StatusConfirmation.invalid',
+    defaultMessage: 'INVALID',
+  }
+});

--- a/app/components/StatusConfirmation/tests/index.test.js
+++ b/app/components/StatusConfirmation/tests/index.test.js
@@ -1,0 +1,10 @@
+// import React from 'react';
+// import { shallow } from 'enzyme';
+
+// import StatusConfirmation from '../index';
+
+describe('<StatusConfirmation />', () => {
+  it('Expect to have unit tests specified', () => {
+    expect(true).toEqual(false);
+  });
+});

--- a/app/components/Transaction/index.jsx
+++ b/app/components/Transaction/index.jsx
@@ -22,6 +22,7 @@ import { CONFIRMATIONS } from 'containers/Transactions/constants';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import ColoredHash from 'components/ColoredHash';
+import StatusConfirmation from 'components/StatusConfirmation';
 import getLogo from 'utils/getLogo';
 import './transaction.scss';
 
@@ -54,7 +55,7 @@ const WrapperLink = styled.div.attrs({
   font-size: 1.25rem !important;
   width: 44%;
   color: #333;
-  background: #EFF5FB;
+  background: #eff5fb;
   border-color: #e2e7eb;
 `;
 
@@ -72,7 +73,8 @@ const WrapperTxDatetime = styled.div.attrs({
   color: #333;
 `;
 
-class Transaction extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+class Transaction extends React.PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
     super(props);
 
@@ -103,34 +105,30 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
   }
 
   getHighlightIfOwner(address) {
-    return (this.isOwner(address) ? 'text-success' : '');
+    return this.isOwner(address) ? 'text-success' : '';
   }
 
   isOwner(address) {
-    return (this.props.addr ? this.props.addr === address : false);
+    return this.props.addr ? this.props.addr === address : false;
   }
 
   render() {
-    const isValid = this.props.valid;
-    let statusCSSClass = 'btn btn-primary btn-block font-weight-light w-50';
-    statusCSSClass = (isValid ?  `${statusCSSClass} btn-blue`: (this.props.confirmations === 0 ? `${statusCSSClass} btn-warning` : `${statusCSSClass} btn-danger`));
+    let statusCSSClass =
+      'wrapper-btn-block btn btn-primary btn-block font-weight-light w-50';
 
-    const status = (
-      isValid ?
-        this.props.confirmations < CONFIRMATIONS ?
-          this.props.confirmations === 0 ?
-            'UNCONFIRMED' :
-            this.props.confirmations > 1 ?
-              `${this.props.confirmations} CONFIRMATIONS` :
-              `${this.props.confirmations} CONFIRMATION`
-          :
-          'CONFIRMED'
-        :
-        this.props.confirmations === 0 ?
-          'UNCONFIRMED' :
-          'INVALID'
-    );
+    const invalidClass = confirmations =>
+      confirmations === 0
+        ? `${statusCSSClass} tx-invalid btn-warning`
+        : `${statusCSSClass} tx-invalid btn-danger`;
 
+    statusCSSClass = this.props.valid
+      ? `${statusCSSClass} btn-blue`
+      : invalidClass(this.props.confirmations);
+
+    const status = StatusConfirmation({
+      ...this.props,
+      confirmed: CONFIRMATIONS,
+    });
     const tokenLogo = getLogo(this.props.propertyid, this.props);
 
     let arrowcname;
@@ -154,42 +152,26 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
     const sendercopyid = `s-${txcopyid}`;
     const referercopyid = `r-${txcopyid}`;
 
-    const TransactionLabel = (tx, propertyname) => (tx.type_int === 51 ?
-        <span>{tx.type} crowdsale started</span> :
-      <div>
-        <div className="p-md-2 pt-xs-2 pr-xs-2">
-            <span className="title d-block-down-md">
-              {( propertyname || tx.type) }
-            </span>
-        </div>
-          <div className="p-md-2 pt-xs-2 pl-xs-2">
-            <span className="title d-block-down-md">
-              <SanitizedFormattedNumber value={transactionAmount}/>
-            </span>
-        </div>
-      </div>
-    );
-
     return (
       <div className="transation-result mx-auto text-center-down-md">
         <Row className="align-items-end pb-0">
           <Col sm="12" md="1">
-            <IMG src={tokenLogo}/>
+            <IMG src={tokenLogo} />
           </Col>
           <Col sm="12" md="5">
             <Row className="d-flex flex-xs-column flex-center-down-md mb-2">
               <div className="p-md-2 pt-xs-2 pr-xs-2">
-                <span className="title d-block-down-md">
-                  {this.props.type}
-                </span>
+                <span className="title d-block-down-md">{this.props.type}</span>
               </div>
               <div className="p-md-2 pt-xs-2 pl-xs-2">
                 <span className="title d-block-down-md">
-                  <SanitizedFormattedNumber value={transactionAmount}/>
+                  <SanitizedFormattedNumber value={transactionAmount} />
                 </span>
               </div>
               <div className="p-md-2 pb-sm-2">
-                <span className="title text-muted">{this.props.propertyname} (#{this.props.propertyid})</span>
+                <span className="title text-muted">
+                  {this.props.propertyname} (#{this.props.propertyid})
+                </span>
               </div>
             </Row>
             <Row className="d-flex flex-center-down-md mb-1 mt-1">
@@ -203,10 +185,21 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
                   <ColoredHash hash={this.props.txid} />
                 </Link>
               </WrapperTx>
-              <CopyToClipboard text={this.props.txid} onCopy={this.toggleTxTooltip}>
-                <StyledCopyIcon className="d-inline-flex d-md-none" size={24} id={txcopyid}/>
+              <CopyToClipboard
+                text={this.props.txid}
+                onCopy={this.toggleTxTooltip}
+              >
+                <StyledCopyIcon
+                  className="d-inline-flex d-md-none"
+                  size={24}
+                  id={txcopyid}
+                />
               </CopyToClipboard>
-              <Tooltip hideArrow isOpen={this.state.tooltipTxOpen} target={txcopyid}>
+              <Tooltip
+                hideArrow
+                isOpen={this.state.tooltipTxOpen}
+                target={txcopyid}
+              >
                 Transaction Id Copied
               </Tooltip>
             </Row>
@@ -214,16 +207,16 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
           <Col sm="12" md="5">
             <div className="d-flex flex-column text-center align-items-center">
               <WrapperTxDatetime>
-                <FormattedUnixDateTime datetime={this.props.blocktime}/>
+                <FormattedUnixDateTime datetime={this.props.blocktime} />
               </WrapperTxDatetime>
               <Link
-                  className={statusCSSClass}
-                  to={{
-                    pathname: `/tx/${this.props.txid}`,
-                    state: { state: this.props.state },
-                  }}
-                >
-                  {status}
+                className={statusCSSClass}
+                to={{
+                  pathname: `/tx/${this.props.txid}`,
+                  state: { state: this.props.state },
+                }}
+              >
+                {status}
               </Link>
             </div>
           </Col>
@@ -234,7 +227,9 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
               <AddressWrapper>
                 <WrapperLink>
                   <StyledLink
-                    className={` ${this.getHighlightIfOwner(this.props.sendingaddress)}`}
+                    className={` ${this.getHighlightIfOwner(
+                      this.props.sendingaddress,
+                    )}`}
                     to={{
                       pathname: `/address/${this.props.sendingaddress}`,
                       state: { state: this.props.state },
@@ -243,15 +238,34 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
                     {this.props.sendingaddress}
                   </StyledLink>
                 </WrapperLink>
-                <CopyToClipboard text={this.props.sendingaddress} onCopy={this.toggleSenderTooltip}>
-                  <StyledCopyIcon className="d-inline-flex" size={24} id={sendercopyid}/>
+                <CopyToClipboard
+                  text={this.props.sendingaddress}
+                  onCopy={this.toggleSenderTooltip}
+                >
+                  <StyledCopyIcon
+                    className="d-inline-flex"
+                    size={24}
+                    id={sendercopyid}
+                  />
                 </CopyToClipboard>
-                <Tooltip hideArrow isOpen={this.state.tooltipSenderOpen} target={sendercopyid}>
+                <Tooltip
+                  hideArrow
+                  isOpen={this.state.tooltipSenderOpen}
+                  target={sendercopyid}
+                >
                   Sender Address Copied
                 </Tooltip>
               </AddressWrapper>
-              <ArrowIconRight size={20} color="gray" className={`d-none ${arrowcnameright} ${arrowcname}`}/>
-              <ArrowIconDown size={20} color="gray" className={`d-md-none ${arrowcname}`}/>
+              <ArrowIconRight
+                size={20}
+                color="gray"
+                className={`d-none ${arrowcnameright} ${arrowcname}`}
+              />
+              <ArrowIconDown
+                size={20}
+                color="gray"
+                className={`d-md-none ${arrowcname}`}
+              />
               <AddressWrapper className={showreferencecname}>
                 <WrapperLink>
                   <StyledLink
@@ -264,10 +278,21 @@ class Transaction extends React.PureComponent { // eslint-disable-line react/pre
                     {this.props.referenceaddress}
                   </StyledLink>
                 </WrapperLink>
-                <CopyToClipboard text={this.props.referenceaddress} onCopy={this.toggleRefererTooltip}>
-                  <StyledCopyIcon className="d-inline-flex" size={24} id={referercopyid}/>
+                <CopyToClipboard
+                  text={this.props.referenceaddress}
+                  onCopy={this.toggleRefererTooltip}
+                >
+                  <StyledCopyIcon
+                    className="d-inline-flex"
+                    size={24}
+                    id={referercopyid}
+                  />
                 </CopyToClipboard>
-                <Tooltip hideArrow isOpen={this.state.tooltipRefererOpen} target={referercopyid}>
+                <Tooltip
+                  hideArrow
+                  isOpen={this.state.tooltipRefererOpen}
+                  target={referercopyid}
+                >
                   Reference Address Copied
                 </Tooltip>
               </AddressWrapper>
@@ -296,11 +321,14 @@ Transaction.propTypes = {
 
 function mapDispatchToProps(dispatch) {
   return {
-    changeRoute: (url) => dispatch(routeActions.push(url)),
+    changeRoute: url => dispatch(routeActions.push(url)),
     dispatch,
   };
 }
 
-const withConnect = connect(null, mapDispatchToProps);
+const withConnect = connect(
+  null,
+  mapDispatchToProps,
+);
 
 export default compose(withConnect)(Transaction);

--- a/app/components/TransactionHistory/index.jsx
+++ b/app/components/TransactionHistory/index.jsx
@@ -98,7 +98,7 @@ class TransactionHistory extends React.PureComponent {
           attr="y"
           attrAxis="x"
           orientation="left"
-          title="Number of transactions"
+          title="Transactions"
         />
         {crosshairValues && (
           <Crosshair

--- a/app/components/TransactionInfo/index.jsx
+++ b/app/components/TransactionInfo/index.jsx
@@ -26,6 +26,7 @@ import {
 import TransactionAmount from 'components/TransactionAmount';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import ContainerBase from 'components/ContainerBase';
+import StatusConfirmation from 'components/StatusConfirmation';
 
 import { CONFIRMATIONS } from 'containers/Transactions/constants';
 import { API_URL_BASE } from 'containers/App/constants';
@@ -58,36 +59,21 @@ const A = styled.a`
 `;
 
 function TransactionInfo(props) {
-  let collapseOmniData = false;
+  // let collapseOmniData = false;
   let collapseDecoded = false;
-  const toggleRawData = () => (collapseOmniData = !collapseOmniData);
+  // const toggleRawData = () => (collapseOmniData = !collapseOmniData);
   const toggleDecoded = () => (collapseDecoded = !collapseDecoded);
 
-  const isValid = props.valid;
-  const statusColor = isValid
+  const statusColor = props.valid
     ? 'btn btn-group btn-primary btn-block btn-blue font-weight-light'
     : props.confirmations === 0
       ? 'btn btn-group btn-primary btn-block btn-warning font-weight-light'
       : 'btn btn-group btn-primary btn-block btn-danger font-weight-light';
 
-  const confirmedUnconfirmed = confirmations =>
-    confirmations === 0
-      ? 'UNCONFIRMED'
-      : pluralizeConfirmations(confirmations);
-
-  const pluralizeConfirmations = confirmations =>
-    confirmations > 1
-      ? `${props.confirmations} CONFIRMATIONS`
-      : `${props.confirmations} CONFIRMATION`;
-
-  const getStatus = tx => {
-    if (tx.valid) {
-      return tx.confirmations < CONFIRMATIONS
-        ? confirmedUnconfirmed(tx.confirmations)
-        : 'CONFIRMED';
-    }
-    return tx.confirmations === 0 ? 'UNCONFIRMED' : 'INVALID';
-  };
+  const status = StatusConfirmation({
+    ...props,
+    confirmed: CONFIRMATIONS,
+  });
   const invalidReason =
     props.confirmations === 0 ? '' : `Reason: ${props.invalidreason || ''}`;
   const rawTransactionURL = `${API_URL_BASE}/transaction/tx/${props.txid}`;
@@ -240,9 +226,9 @@ function TransactionInfo(props) {
                 </td>
                 <td className="field">
                   <div className={statusColor} style={{ width: '35%' }}>
-                    {getStatus(props)}
+                    {status}
                   </div>
-                  <div className="text-left">{!isValid && invalidReason}</div>
+                  <div className="text-left">{!props.valid && invalidReason}</div>
                 </td>
               </tr>
               <tr>
@@ -332,6 +318,7 @@ TransactionInfo.propTypes = {
   propertyname: PropTypes.string,
   propertyid: PropTypes.number,
   invalidreason: PropTypes.any,
+  valid: PropTypes.bool,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/BlockDetail/messages.js
+++ b/app/containers/BlockDetail/messages.js
@@ -4,13 +4,18 @@
  * This contains all the text for the BlockDetail component.
  */
 import { defineMessages } from 'react-intl';
+import React from 'react';
 
 export default defineMessages({
   header: {
     id: 'app.containers.BlockDetail.header',
-    defaultMessage: 'Block {blockNumber}, {txCount} Transactions, created at {timestamp}',
+    defaultMessage: 'Block {blockNumber}, {txCount} Transactions, created at {timestamp}, {confirmations} confirmations',
     one: 'Block',
     other: 'Blocks',
     zero: 'Blocks',
+  },
+  doesNotHaveTransactions: {
+    id: 'app.containers.BlockDetail.doesNotHaveTransactions',
+    defaultMessage: "The block doesn't have any transactions",
   },
 });

--- a/app/containers/Blocks/actions.js
+++ b/app/containers/Blocks/actions.js
@@ -19,6 +19,7 @@ import {
   LOAD_BLOCKS,
   LOAD_BLOCKS_SUCCESS,
   LOAD_BLOCKS_ERROR,
+  DISABLE_BLOCKS_LOADING,
 } from './constants';
 
 /**
@@ -58,5 +59,18 @@ export function blocksLoadingError(error) {
   return {
     type: LOAD_BLOCKS_ERROR,
     error,
+  };
+}
+
+/**
+ * Dispatched when loading the blocks fails
+ *
+ * @param  {object} error The error
+ *
+ * @return {object} An action object with a type of LOAD_BLOCKS_ERROR passing the error
+ */
+export function disableLoading() {
+  return {
+    type: DISABLE_BLOCKS_LOADING,
   };
 }

--- a/app/containers/Blocks/constants.js
+++ b/app/containers/Blocks/constants.js
@@ -7,3 +7,4 @@
 export const LOAD_BLOCKS = 'omniexplorer/App/LOAD_BLOCKS';
 export const LOAD_BLOCKS_SUCCESS = 'omniexplorer/App/LOAD_BLOCKS_SUCCESS';
 export const LOAD_BLOCKS_ERROR = 'omniexplorer/App/LOAD_BLOCKS_ERROR';
+export const DISABLE_BLOCKS_LOADING = 'omniexplorer/App/LOAD_BLOCKS_ERROR';

--- a/app/containers/Blocks/reducer.js
+++ b/app/containers/Blocks/reducer.js
@@ -18,11 +18,12 @@ import {
   LOAD_BLOCKS,
   LOAD_BLOCKS_ERROR,
   LOAD_BLOCKS_SUCCESS,
+  DISABLE_BLOCKS_LOADING,
 } from './constants';
 
 // The initial state of the App
 export const initialState = fromJS({
-  loading: false,
+  loading: true,
   appendBlocks: false,
   error: false,
   blocks: [],
@@ -33,6 +34,9 @@ export const initialState = fromJS({
 
 function blocksReducer(state = initialState, action) {
   switch (action.type) {
+    case DISABLE_BLOCKS_LOADING:
+      return state
+        .set('loading', false);
     case LOAD_BLOCKS:
       return state
         .set('loading', true)
@@ -45,7 +49,7 @@ function blocksReducer(state = initialState, action) {
         .set('blocks', orderBy(blocks, 'timestamp', 'desc'))
         .set('loading', false)
         .set('error', false)
-        .set('previousBlock', blockValues[0].block - 1);
+        .set('previousBlock', (blocks.length ? blockValues[0].block - 1 : null));
     case LOAD_BLOCKS_ERROR:
       return state
         .set('error', action.error)

--- a/app/containers/CrowdsaleDetail/index.jsx
+++ b/app/containers/CrowdsaleDetail/index.jsx
@@ -48,6 +48,7 @@ import LinkedinIcon from 'react-icons/lib/io/social-linkedin';
 
 import List from 'components/List';
 import CrowdsaleTransaction from 'components/CrowdsaleTransaction';
+import ListHeader from 'components/ListHeader';
 
 import crowdsalesMessages from './messages';
 import makeSelectCrowdsaleDetail from './selectors';
@@ -56,7 +57,6 @@ import reducer from './reducer';
 import saga from './saga';
 import './crowdsaledetail.scss';
 import { setPage } from '../Transactions/actions';
-import ListHeader from 'components/ListHeader';
 
 const StyledCard = styled(Card).attrs({
   className: 'text-center',

--- a/app/containers/FullBlockList/index.jsx
+++ b/app/containers/FullBlockList/index.jsx
@@ -5,67 +5,14 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { compose } from 'redux';
 import Blocks from 'containers/Blocks';
-import { loadBlocks } from 'containers/Blocks/actions';
-import styled from 'styled-components';
-import { Col } from 'reactstrap';
-import { FormattedMessage } from 'react-intl';
-import messages from './messages';
 
-const LoadMoreBlocks = styled.div.attrs({
-  className: 'text-center',
-})`
-  background-color: #7c8fa0;
-  color: white;
-
-  cursor: pointer;
-  padding: 0.5rem;
-  letter-spacing: 0.1rem;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-size: 14px;
-
-  a {
-    color: white;
-  }
-`;
-
-export class FullBlockList extends React.PureComponent {
-  // eslint-disable-line react/prefer-stateless-function
-  render() {
-    // const loadMoreBlocks = (
-    //   <LoadMoreBlocks onClick={() => this.props.loadBlocks()}>
-    //     <Col sm>
-    //       <FormattedMessage {...messages.footer} />
-    //     </Col>
-    //   </LoadMoreBlocks>
-    // );
-
-    return (
-      <div>
-        <Blocks withPagination />
-      </div>
-    );
-  }
+export function FullBlockList() {
+  return (
+    <div>
+      <Blocks withPagination />
+    </div>
+  );
 }
 
-FullBlockList.propTypes = {
-  dispatch: PropTypes.func.isRequired,
-  // loadBlocks: PropTypes.func.isRequired,
-};
-
-function mapDispatchToProps(dispatch) {
-  return {
-    dispatch,
-    loadBlocks: () => dispatch(loadBlocks()),
-  };
-}
-
-const withConnect = connect(
-  null,
-  mapDispatchToProps,
-);
-
-export default compose(withConnect)(FullBlockList);
+export default FullBlockList;

--- a/app/containers/HomePage/index.jsx
+++ b/app/containers/HomePage/index.jsx
@@ -54,7 +54,7 @@ class HomePage extends React.PureComponent {
               state: { state: this.props.state },
             }}
           >
-            View full block list...
+            Navigate full block list...
           </Link>
         </Col>
       </ViewFullBlockList>


### PR DESCRIPTION
+ Timestamp, Transactions, USD Value columns be moved closer to the Height.
+ show `non block transations` where jump to block below first block  or if higher than latest block.
+ change Invalid TXs: in the tooltip to Invalid.
+ added number of confirmations to the block detail banner.
+ renamed `View full block list...` to `Navigate full block list…`.
+ moved the tooltip locations to right for transactions & usd value in block records.
+ removed tooltips headers (Property:Count or Property:Value).
+ removed `This represents` or `The value is` from column heading tooltips.
+ now only block number & block hash are clickable in block records.
+ included Invalid count transactions only when it’s not 0.
+  show `non block transations` when the block is empty of transactions.
+ changed tooltip text to None for transactions count, and $0 for $0 when there are no OL tx’s in the block.
+ added asset logos to block records
+ added `StatusConfirmation` Component
+ #refactoring use of new component `StatusConfirmation` (Transaction, TransactionInfo, Crodwsale Transaction)
+ clean code