### PR TITLE
Feedback new release

### DIFF
--- a/app/components/BlockList/index.jsx
+++ b/app/components/BlockList/index.jsx
@@ -172,7 +172,7 @@ class BlockList extends React.PureComponent {
                 <FormattedMessage {...messages.columns.usdtooltip} />
               </UncontrolledTooltip>
             </th>
-            <th className="text-right">
+            <th className="text-center">
               <FormattedMessage {...messages.columns.blockhash} />
             </th>
           </tr>
@@ -217,7 +217,7 @@ class BlockList extends React.PureComponent {
                   {getOmniTxValues(block)}
                 </UncontrolledTooltip>
               </td>
-              <td className="text-right">
+              <td className="text-center">
                 <Link
                   to={{
                     pathname: `/block/${block.block}`,

--- a/app/components/FooterRow/index.jsx
+++ b/app/components/FooterRow/index.jsx
@@ -1,0 +1,22 @@
+/**
+ *
+ * ContainerBase
+ *
+ */
+import styled from 'styled-components';
+import { Row } from 'reactstrap';
+
+const FooterRow = styled(Row)`
+  background-color: #7c8fa0;
+  color: white;
+
+  letter-spacing: 0.1rem;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+
+  a {
+    color: white;
+  }
+`;
+
+export default FooterRow;

--- a/app/components/FooterRow/tests/index.test.js
+++ b/app/components/FooterRow/tests/index.test.js
@@ -1,0 +1,10 @@
+// import React from 'react';
+// import { shallow } from 'enzyme';
+
+// import FooterRow from '../index';
+
+describe('<FooterRow />', () => {
+  it('Expect to have unit tests specified', () => {
+    expect(true).toEqual(false);
+  });
+});

--- a/app/components/NoOmniBlockTransactions/index.jsx
+++ b/app/components/NoOmniBlockTransactions/index.jsx
@@ -5,34 +5,38 @@
  */
 
 import React from 'react';
-// import styled from 'styled-components';
-
 import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import styled from 'styled-components';
+// import styled from 'styled-components';
 
 const StyledH3 = styled.h3`
-      padding: 3rem 0;
-    `;
+  padding: 3rem 0;
+`;
 
-function NoOmniBlockTransactions() {
+function NoOmniBlockTransactions(props={useDefaults: true}) {
   return (
     <StyledH3 className="lead text-center">
       <p className="h3">
         <FormattedMessage {...messages.header} />
       </p>
       <p className="h5">
+        {!props.mainText && props.useDefaults &&
         <FormattedMessage {...messages.main} />
+        }
+        {props.mainText &&
+        props.mainText
+        }
       </p>
       <p className="h5">
-        <FormattedMessage {...messages.secondary} />
+        {props.useDefaults &&
+          <FormattedMessage {...messages.secondary} />
+        }
       </p>
     </StyledH3>
   );
 }
 
-NoOmniBlockTransactions.propTypes = {
-
-};
+NoOmniBlockTransactions.propTypes = {};
 
 export default NoOmniBlockTransactions;

--- a/app/components/TransactionListHeader/index.jsx
+++ b/app/components/TransactionListHeader/index.jsx
@@ -29,7 +29,7 @@ class TransactionListHeader extends React.PureComponent { // eslint-disable-line
 
   render() {
     return (
-      <ListHeader {...this.props} message={messages.header}>
+      <ListHeader {...this.props} message={(this.props.customHeader || messages.header)}>
         <ButtonDropdown size="sm" isOpen={this.state.dropdownOpen} toggle={this.toggle} className="float-md-right">
           <DropdownToggle caret color="info" className="font-weight-light">
             <FormattedMessage {...messages.transactionTypes} />

--- a/app/containers/App/index.jsx
+++ b/app/containers/App/index.jsx
@@ -18,6 +18,7 @@ import styled from 'styled-components';
 import { Route, Switch } from 'react-router-dom';
 import HomePage from 'containers/HomePage/Loadable';
 import TransactionDetail from 'containers/TransactionDetail';
+import Transactions from 'containers/Transactions';
 import AddressDetail from 'containers/AddressDetail';
 import NotFoundPage from 'containers/NotFoundPage/Loadable';
 import Search from 'containers/Search/Loadable';
@@ -85,6 +86,10 @@ class App extends React.Component {
           <Route
             path="/tx/:tx"
             component={TransactionDetail}
+          />
+          <Route
+            path="/transactions/unconfirmed"
+            component={Transactions}
           />
           <Route
             path="/address/:address/:page(\d+)?"

--- a/app/containers/BlockDetail/index.jsx
+++ b/app/containers/BlockDetail/index.jsx
@@ -70,7 +70,7 @@ export class BlockDetail extends React.PureComponent {
 
     let content;
     if (this.block < FIRST_BLOCK || !block.transactions) {
-      content = <NoOmniBlockTransactions />;
+      content = <NoOmniBlockTransactions mainText={block.error} useDefaults={false} />;
     } else if (!block.transactions.length) {
       content = (
         <h3 className="text-center" style={{ margin: '3rem' }}>

--- a/app/containers/Blocks/index.jsx
+++ b/app/containers/Blocks/index.jsx
@@ -23,13 +23,19 @@ import isEmpty from 'lodash/isEmpty';
 import injectSaga from 'utils/injectSaga';
 import sagaBlocks from 'containers/Blocks/saga';
 import { FIRST_BLOCK } from 'containers/App/constants';
+import { Row, Col } from 'reactstrap';
 
-import { makeSelectBlocks, makeSelectLoading, makeSelectPreviousBlock } from './selectors';
+import {
+  makeSelectBlocks,
+  makeSelectLoading,
+  makeSelectPreviousBlock,
+} from './selectors';
 import { disableLoading, loadBlocks } from './actions';
 import messages from './messages';
 
 const StyledContainer = styled(ContainerBase)`
   overflow: auto;
+  padding-bottom: 0;
 `;
 
 const A = styled.a`
@@ -48,11 +54,7 @@ export class Blocks extends React.Component {
   }
 
   componentDidMount() {
-    if (this.block >= FIRST_BLOCK || isEmpty(this.block)) {
-      this.props.loadBlocks(this.block);
-    } else {
-      this.props.disableLoading();
-    }
+    this.props.loadBlocks(this.block);
   }
 
   render() {
@@ -60,14 +62,14 @@ export class Blocks extends React.Component {
     let pagination;
 
     if (this.props.loading && !this.props.previousBlock) {
-      content = <LoadingIndicator/>;
+      content = <LoadingIndicator />;
     } else {
       const { blocks } = this.props.blocks;
       const list =
         isEmpty(blocks) || this.block > blocks[0].block + 9 ? (
-          <NoOmniBlocks/>
+          <NoOmniBlocks />
         ) : (
-          <BlockList blocks={blocks}/>
+          <BlockList blocks={blocks} />
         );
 
       content = <div>{list}</div>;
@@ -79,8 +81,9 @@ export class Blocks extends React.Component {
       const hashLink = blockNum => `${pathname}${blockNum}`;
       const previousBlockSet = () => {
         let result;
+        const previous = this.block - 10;
         if (isEmpty(blocks)) {
-          result = this.block - 10;
+          result = previous > FIRST_BLOCK ? previous : FIRST_BLOCK;
         } else if (this.block > blocks[0].block + 9) {
           result = blocks[0].block;
         } else {
@@ -100,22 +103,35 @@ export class Blocks extends React.Component {
       };
 
       pagination = (
-        <h3 align="center">
-          <A href={hashLink(previousBlockSet())}>&lt;&lt; Previous</A>
-          &nbsp;<span className="d-none d-sm-inline">Blocks mined</span>&nbsp;
-          <A href={hashLink(nextBlockSet())}>Next &gt;&gt;</A>
-        </h3>
+        <Row>
+          <Col sm={{size:2,offset:1}}>
+            <h3>
+            <A
+              href={hashLink(previousBlockSet())}
+            >
+              &lt;&lt; Previous
+            </A>
+            </h3>
+          </Col>
+          <Col sm={{size:2, offset:6}} className="text-right">
+            <h3>
+            <A href={hashLink(nextBlockSet())}>Next &gt;&gt;</A>
+            </h3>
+          </Col>
+        </Row>
       );
     }
 
-    const Footer = this.props.footer || <div/>;
+    const Footer = this.props.footer || <div />;
     return (
       <StyledContainer fluid>
         <ListHeader message={messages.header}>
-          <JumpToBlock/>
+          <JumpToBlock />
         </ListHeader>
-        {this.props.withPagination && pagination}
+        <h3 align="center"><span className="d-none d-sm-inline">Blocks</span>
+        </h3>
         {content}
+        {this.props.withPagination && pagination}
         {Footer}
       </StyledContainer>
     );

--- a/app/containers/Blocks/saga.js
+++ b/app/containers/Blocks/saga.js
@@ -1,11 +1,11 @@
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
-import { LOAD_BLOCKS, ADD_BLOCKS } from 'containers/Blocks/constants';
+import { ADD_BLOCKS, LOAD_BLOCKS } from 'containers/Blocks/constants';
 import { API_URL_BASE } from 'containers/App/constants';
 import request from 'utils/request';
 import { blocksLoaded, blocksLoadingError } from './actions';
 import { makeSelectBlocks } from './selectors';
 
-export function* getBlocks({block}) {
+export function* getBlocks({ block }) {
   const state = yield select(makeSelectBlocks());
   const currentBlock = block || (state.appendBlocks ? state.previousBlock || '' : '');
 

--- a/app/containers/FullBlockList/index.jsx
+++ b/app/containers/FullBlockList/index.jsx
@@ -6,11 +6,41 @@
 
 import React from 'react';
 import Blocks from 'containers/Blocks';
+import { Col, Row } from 'reactstrap';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const FooterRow = styled(Row)`
+      background-color: #7c8fa0;
+      color: white;
+
+      letter-spacing: 0.1rem;
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      font-size: 14px;
+
+      a {
+        color: white;
+      }
+    `;
 
 export function FullBlockList() {
+  const footer = (
+    <FooterRow>
+      <Col sm>
+        <Link
+          to={{
+            pathname: `/transactions/unconfirmed`,
+            state: { state: this },
+          }}
+        >
+          View Unconfirmed Transactions...
+        </Link>
+      </Col>
+    </FooterRow>
+  );
   return (
     <div>
-      <Blocks withPagination />
+      <Blocks withPagination footer={footer}/>
     </div>
   );
 }

--- a/app/containers/HomePage/index.jsx
+++ b/app/containers/HomePage/index.jsx
@@ -10,6 +10,11 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { routeActions } from 'redux-simple-router';
 import styled from 'styled-components';
 
 import { Container, Col, Row } from 'reactstrap';
@@ -18,11 +23,8 @@ import ServiceBlock from 'components/ServiceBlock';
 import HeaderMessage from 'components/HeaderMessage';
 import TransactionHistory from 'components/TransactionHistory';
 import Blocks from 'containers/Blocks';
-import { Link } from 'react-router-dom';
-import { routeActions } from 'redux-simple-router';
-import connect from 'react-redux/es/connect/connect';
-import { compose } from 'redux';
-import PropTypes from 'prop-types';
+
+import FooterRow from 'components/FooterRow';
 
 const Layout = styled(Container)`
   background-color: #f5f5f5;
@@ -32,32 +34,33 @@ const Layout = styled(Container)`
 class HomePage extends React.PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    const ViewFullBlockList = styled(Row)`
-      background-color: #7c8fa0;
-      color: white;
-
-      letter-spacing: 0.1rem;
-      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-      font-size: 14px;
-
-      a {
-        color: white;
-      }
-    `;
-
-    const viewFullList = (
-      <ViewFullBlockList>
-        <Col sm>
-          <Link
-            to={{
-              pathname: `/blocks`,
-              state: { state: this.props.state },
-            }}
-          >
-            Navigate full block list...
-          </Link>
-        </Col>
-      </ViewFullBlockList>
+    const footer = (
+      <div>
+        <FooterRow>
+          <Col sm>
+            <Link
+              to={{
+                pathname: `/blocks`,
+                state: { state: this.props.state },
+              }}
+            >
+              Navigate full block list...
+            </Link>
+          </Col>
+        </FooterRow>
+        <FooterRow>
+          <Col sm>
+            <Link
+              to={{
+                pathname: `/transactions/unconfirmed`,
+                state: { state: this.props.state },
+              }}
+            >
+              View Unconfirmed Transactions...
+            </Link>
+          </Col>
+        </FooterRow>
+      </div>
     );
 
     return (
@@ -77,7 +80,7 @@ class HomePage extends React.PureComponent {
         </Row>
         <Row>
           <Col sm>
-            <Blocks footer={viewFullList} />
+            <Blocks footer={footer} />
           </Col>
         </Row>
       </Layout>

--- a/app/containers/Transactions/actions.js
+++ b/app/containers/Transactions/actions.js
@@ -21,6 +21,7 @@ import {
   LOAD_TRANSACTIONS_ERROR,
   SET_PAGE,
   SET_TRANSACTION_TYPE,
+  LOAD_UNCONFIRMED,
 } from './constants';
 
 /**
@@ -89,5 +90,16 @@ export function setTransactionType(txType) {
   return {
     type: SET_TRANSACTION_TYPE,
     txType,
+  };
+}
+
+/**
+ * Load the transactions, this action starts the request saga
+ *
+ * @return {object} An action object with a type of LOAD_TRANSACTIONS
+ */
+export function loadUnconfirmed() {
+  return {
+    type: LOAD_UNCONFIRMED,
   };
 }

--- a/app/containers/Transactions/constants.js
+++ b/app/containers/Transactions/constants.js
@@ -11,4 +11,5 @@ export const LOAD_TRANSACTIONS_ERROR =
   'omniexplorer/App/LOAD_TRANSACTIONS_ERROR';
 export const SET_PAGE = 'omniexplorer/App/SET_PAGE';
 export const SET_TRANSACTION_TYPE = 'omniexplorer/App/SET_TRANSACTION_TYPE';
+export const LOAD_UNCONFIRMED = 'omniexplorer/App/LOAD_UNCONFIRMED';
 export const CONFIRMATIONS = 100;

--- a/app/containers/Transactions/messages.js
+++ b/app/containers/Transactions/messages.js
@@ -1,0 +1,16 @@
+/*
+ * TransactionListHeader Messages
+ *
+ * This contains all the text for the TransactionListHeader component.
+ */
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  unconfirmedHeader: {
+    id: 'app.components.Transactions.unconfirmedHeader',
+    defaultMessage: 'Latest Unconfirmed Transactions',
+    one: 'Transaction',
+    other: 'Transactions',
+    zero: 'Transactions',
+  },
+});

--- a/app/containers/Transactions/reducer.js
+++ b/app/containers/Transactions/reducer.js
@@ -18,6 +18,7 @@ import {
   LOAD_TRANSACTIONS_ERROR,
   SET_PAGE,
   SET_TRANSACTION_TYPE,
+  LOAD_UNCONFIRMED,
 } from './constants';
 
 // The initial state of the App
@@ -28,6 +29,7 @@ export const initialState = fromJS({
   pageCount: 0,
   currentPage: 1,
   txType: null,
+  unconfirmed: false,
 });
 
 function transactionsReducer(state = initialState, action) {
@@ -37,11 +39,19 @@ function transactionsReducer(state = initialState, action) {
         .set('loading', true)
         .set('error', false)
         .set('transactions', [])
-        .set('pageCount', 0);
+        .set('pageCount', 0)
+        .set('unconfirmed', false);
+    case LOAD_UNCONFIRMED:
+      return state
+      .set('loading', true)
+      .set('error', false)
+      .set('transactions', [])
+      .set('unconfirmed', true);
     case LOAD_TRANSACTIONS_SUCCESS:
+      const unconfirmed = state.get('unconfirmed');
       return state
         .set('transactions', action.transactions)
-        .set('pageCount', action.pages)
+        .set('pageCount', unconfirmed ? action.transactions.length : action.pages)
         .set('loading', false)
         .set('error', false);
     case LOAD_TRANSACTIONS_ERROR:

--- a/app/containers/Transactions/saga.js
+++ b/app/containers/Transactions/saga.js
@@ -2,12 +2,23 @@ import { select, all, call, put, takeLatest } from 'redux-saga/effects';
 import {
   LOAD_TRANSACTIONS,
   SET_TRANSACTION_TYPE,
+  LOAD_UNCONFIRMED,
 } from 'containers/Transactions/constants';
 import { API_URL_BASE } from 'containers/App/constants';
 import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 import { transactionsLoaded, transactionsLoadingError } from './actions';
 import { makeSelectTransactions } from './selectors';
+
+export function* getUnconfirmed(){
+  const requestURL = `${API_URL_BASE}/transaction/unconfirmed`;
+  try {
+    const transactions = yield call(request, requestURL);
+    yield put(transactionsLoaded(transactions.data,1));
+  } catch (err) {
+    yield put(transactionsLoadingError(err));
+  }
+}
 
 export function* getTransactions({ addr }) {
   const state = yield select(makeSelectTransactions());
@@ -22,14 +33,14 @@ export function* getTransactions({ addr }) {
     const getTransactionsOptions = {
       type: 'cors',
     };
-  
+
     const options = { tx_type: txType };
-    
+
     if(addr){
       options.addr = addr;
     }
     const body = encoderURIParams({ addr, tx_type: txType });
-    
+
     Object.assign(getTransactionsOptions, {
       method: 'POST',
       headers: {
@@ -56,5 +67,6 @@ export default function* root() {
   yield all([
     takeLatest(LOAD_TRANSACTIONS, getTransactions),
     takeLatest(SET_TRANSACTION_TYPE, getTransactions),
+    takeLatest(LOAD_UNCONFIRMED, getUnconfirmed),
   ]);
 }

--- a/app/containers/Transactions/selectors.js
+++ b/app/containers/Transactions/selectors.js
@@ -17,4 +17,7 @@ const makeSelectTransactions = () =>
 const makeSelectLoading = () =>
   createSelector(selectTransactionsDomain, substate => substate.get('loading'));
 
-export { makeSelectTransactions, makeSelectLoading, selectTransactionsDomain };
+const makeSelectUnconfirmed = () =>
+  createSelector(selectTransactionsDomain, substate => substate.get('unconfirmed'));
+
+export { makeSelectTransactions, makeSelectLoading, selectTransactionsDomain, makeSelectUnconfirmed };


### PR DESCRIPTION
### Changes

+ add unconfirmed transactions to footer of the home page under navigate we add another link that says View Unconfirmed Transactions and then in the footer of the ‘full blocks display page’
+ center block hash title and column
+ when jumping to an invalid/unknown block we do have the proper ‘Block not found’ header but we’re still displaying the text description for a missing transaction, https://dt45325.omniexplorer.info/block/0 , we should remove that text. handle now the service is retrieving `{error:'..'}` when the block not exists
+ move previous & next to bottom
+ centered block hash title and column