### PR TITLE
Fix block headings

### DIFF
--- a/app/containers/Blocks/index.jsx
+++ b/app/containers/Blocks/index.jsx
@@ -128,8 +128,6 @@ export class Blocks extends React.Component {
         <ListHeader message={messages.header}>
           <JumpToBlock />
         </ListHeader>
-        <h3 align="center"><span className="d-none d-sm-inline">Blocks</span>
-        </h3>
         {content}
         {this.props.withPagination && pagination}
         {Footer}

--- a/app/containers/Blocks/messages.js
+++ b/app/containers/Blocks/messages.js
@@ -8,7 +8,7 @@ import { defineMessages } from 'react-intl';
 export default defineMessages({
   header: {
     id: 'app.containers.Blocks.header',
-    defaultMessage: 'Latest Blocks',
+    defaultMessage: 'Blocks',
     one: 'Block',
     other: 'Blocks',
     zero: 'Blocks',


### PR DESCRIPTION
### Changes

+ removed `Blocks heading`
+ renamed `Latest Blocks` to `Blocks