### PR TITLE
Feedback release candidate

### DIFF
--- a/app/components/BlockList/index.jsx
+++ b/app/components/BlockList/index.jsx
@@ -132,17 +132,6 @@ class BlockList extends React.PureComponent {
             </th>
             <th className="text-center">
               <FormattedMessage {...messages.columns.timestamp} />
-              <InformationIcon
-                color="gray"
-                className="ml-1"
-                id="blocktimestamp"
-              />
-              <UncontrolledTooltip
-                placement="right-end"
-                target="blocktimestamp"
-              >
-                <FormattedMessage {...datetimeMessages.utc} />
-              </UncontrolledTooltip>
             </th>
             <th className="text-right">
               <FormattedMessage {...messages.columns.txcount} />

--- a/app/components/NoOmniBlockTransactions/index.jsx
+++ b/app/components/NoOmniBlockTransactions/index.jsx
@@ -8,11 +8,12 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import styled from 'styled-components';
-// import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const StyledH3 = styled.h3`
   padding: 3rem 0;
 `;
+
 
 function NoOmniBlockTransactions(props={useDefaults: true}) {
   return (
@@ -32,6 +33,16 @@ function NoOmniBlockTransactions(props={useDefaults: true}) {
         {props.useDefaults &&
           <FormattedMessage {...messages.secondary} />
         }
+      </p>
+      <p className="text-center">
+        <Link
+          to={{
+            pathname: `/blocks`,
+            state: { state: props.state },
+          }}
+        >
+          Navigate full block list...
+        </Link>
       </p>
     </StyledH3>
   );

--- a/app/containers/Blocks/index.jsx
+++ b/app/containers/Blocks/index.jsx
@@ -29,6 +29,7 @@ import {
   makeSelectBlocks,
   makeSelectLoading,
   makeSelectPreviousBlock,
+  makeSelectLatestBlock,
 } from './selectors';
 import { disableLoading, loadBlocks } from './actions';
 import messages from './messages';
@@ -101,21 +102,31 @@ export class Blocks extends React.Component {
         }
         return result;
       };
-      
+
+      const LinkPrevious = styled(A)``;
+      const LinkNext = (this.props.latest > blocks[0].block)
+        ? styled(A)``
+        : styled(A)`
+          pointer-events: none;
+          text-decoration: none;
+          opacity: 0.5;
+          cursor: not-allowed;
+        `;
+
       pagination = (
         <Row>
           <Col sm={{size:2,offset:1}}>
             <h3>
-              <A href="javascript:void(0)" onClick={this.props.history.goBack}>&lt;&lt; Go back</A>
+              <LinkPrevious
+                href={hashLink(previousBlockSet())}
+              >
+                &lt;&lt; Previous
+              </LinkPrevious>
             </h3>
           </Col>
           <Col sm={{size:2, offset:6}} className="text-right">
             <h3>
-              <A
-                href={hashLink(previousBlockSet())}
-              >
-                View More &gt;&gt;
-              </A>
+              <LinkNext href={hashLink(nextBlockSet())}>Next &gt;&gt;</LinkNext>
             </h3>
           </Col>
         </Row>
@@ -143,6 +154,7 @@ Blocks.propTypes = {
   changeRoute: PropTypes.func,
   loading: PropTypes.bool,
   previousBlock: PropTypes.any,
+  latest: PropTypes.any,
   match: PropTypes.object,
   location: PropTypes.object,
   withPagination: PropTypes.bool,
@@ -152,6 +164,7 @@ const mapStateToProps = createStructuredSelector({
   blocks: makeSelectBlocks(),
   loading: makeSelectLoading(),
   previousBlock: makeSelectPreviousBlock(),
+  latest: makeSelectLatestBlock(),
   location: state => state.get('route').get('location'),
 });
 

--- a/app/containers/Blocks/reducer.js
+++ b/app/containers/Blocks/reducer.js
@@ -29,6 +29,7 @@ export const initialState = fromJS({
   blocks: [],
   pageCount: 0,
   previousBlock: '',
+  latest: -1,
   txType: null,
 });
 
@@ -44,12 +45,16 @@ function blocksReducer(state = initialState, action) {
     case LOAD_BLOCKS_SUCCESS:
       const hasBlocks = state.get('blocks').length > 0;
       const blockValues = action.blocks.blocks;
-      const blocks = (hasBlocks && state.get('appendBlocks') ? state.get('blocks') : []).concat(blockValues);
+      const blocks = (hasBlocks && state.get('appendBlocks')
+        ? state.get('blocks')
+        : []
+      ).concat(blockValues);
       return state
+        .set('latest', action.blocks.latest)
         .set('blocks', orderBy(blocks, 'timestamp', 'desc'))
         .set('loading', false)
         .set('error', false)
-        .set('previousBlock', (blocks.length ? blockValues[0].block - 1 : null));
+        .set('previousBlock', blocks.length ? blockValues[0].block - 1 : null);
     case LOAD_BLOCKS_ERROR:
       return state
         .set('error', action.error)

--- a/app/containers/Blocks/reducer.js
+++ b/app/containers/Blocks/reducer.js
@@ -43,7 +43,7 @@ function blocksReducer(state = initialState, action) {
         .set('error', false);
     case LOAD_BLOCKS_SUCCESS:
       const hasBlocks = state.get('blocks').length > 0;
-      const blockValues = values(action.blocks);
+      const blockValues = action.blocks.blocks;
       const blocks = (hasBlocks && state.get('appendBlocks') ? state.get('blocks') : []).concat(blockValues);
       return state
         .set('blocks', orderBy(blocks, 'timestamp', 'desc'))

--- a/app/containers/Blocks/selectors.js
+++ b/app/containers/Blocks/selectors.js
@@ -19,4 +19,13 @@ const makeSelectLoading = () =>
 const makeSelectPreviousBlock = () =>
   createSelector(selectBlocksDomain, substate => substate.get('previousBlock'));
 
-export { makeSelectBlocks, makeSelectLoading, selectBlocksDomain, makeSelectPreviousBlock };
+const makeSelectLatestBlock = () =>
+  createSelector(selectBlocksDomain, substate => substate.get('latest'));
+
+export {
+  makeSelectBlocks,
+  makeSelectLoading,
+  selectBlocksDomain,
+  makeSelectPreviousBlock,
+  makeSelectLatestBlock,
+};


### PR DESCRIPTION
### Changes

+ removed `UTC` tooltip & icon from block timestamp column header
+ map block results as array
+ added `Navigate full block list...` to `NoOmniBlockTransactions` component
+ rollback to `Previous` & `Next` options
+ added check latest block verification to enable/disable `Next` (blocks) option