### PR TITLE
Fix block navigation

### DIFF
--- a/app/components/TransactionInfo/index.jsx
+++ b/app/components/TransactionInfo/index.jsx
@@ -196,19 +196,21 @@ function TransactionInfo(props) {
                   </Link>
                 </td>
               </tr>
-              <tr>
-                <td className="field">Recipient</td>
-                <td>
-                  <Link
-                    to={{
-                      pathname: `/address/${recipient}`,
-                      state: { state: props.state },
-                    }}
-                  >
-                    {recipient}
-                  </Link>
-                </td>
-              </tr>
+              {recipient &&
+                <tr>
+                  <td className="field">Recipient</td>
+                  <td>
+                    <Link
+                      to={{
+                        pathname: `/address/${recipient}`,
+                        state: { state: props.state },
+                      }}
+                    >
+                      {recipient}
+                    </Link>
+                  </td>
+                </tr>
+              }
               <tr>
                 <td className="field">{dtheader}</td>
                 <td>

--- a/app/containers/Blocks/index.jsx
+++ b/app/containers/Blocks/index.jsx
@@ -104,7 +104,7 @@ export class Blocks extends React.Component {
       };
 
       const LinkPrevious = styled(A)``;
-      const LinkNext = (this.props.latest > blocks[0].block)
+      const LinkNext = (isEmpty(blocks) || this.props.latest > blocks[0].block)
         ? styled(A)``
         : styled(A)`
           pointer-events: none;

--- a/app/containers/Blocks/index.jsx
+++ b/app/containers/Blocks/index.jsx
@@ -117,12 +117,12 @@ export class Blocks extends React.Component {
         <Row>
           <Col sm={{size:2,offset:1}}>
             <h3>
-              <LinkNext href={hashLink(nextBlockSet())}>&lt;&lt; Newer</LinkNext>
+              <LinkPrevious href={hashLink(previousBlockSet())}>&lt;&lt; Older</LinkPrevious>
             </h3>
           </Col>
           <Col sm={{size:2, offset:6}} className="text-right">
             <h3>
-              <LinkPrevious href={hashLink(previousBlockSet())}>Older &gt;&gt;</LinkPrevious>
+              <LinkNext href={hashLink(nextBlockSet())}>Newer &gt;&gt;</LinkNext>
             </h3>
           </Col>
         </Row>


### PR DESCRIPTION
### Changes

+ #improvement show `Recipient` field only when it exists
+ #fix allow to navigate newest if there aren't blocks for the requested listing
+ #ux #improvement `Newer` `Older` swapping