### PR TITLE
Fixes & refactoring to handle token/transactions without id

### DIFF
--- a/app/components/Asset/index.jsx
+++ b/app/components/Asset/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 
 const StyledTD = styled.td.attrs({
   className: 'align-middle',
@@ -24,30 +25,28 @@ function Asset(props) {
     issuer: props[2],
     flags: props[3],
   };
+
   return (
     <tr>
       <StyledTD style={{ width: '56px' }}>
-        <Link
-          to={{
-            pathname: `/asset/${asset.id}`,
-            state: { state: props.state },
-          }}
-        >
-          <AssetLogo asset={asset} prop={asset.id} style={{width: '4rem', height: '4rem'}}/>
-        </Link>
+        <AssetLink asset={asset.id} state={props.state} >
+          <AssetLogo
+            asset={asset}
+            prop={asset.id}
+            style={{
+              width: '4rem',
+              height: '4rem',
+            }}
+          />
+        </AssetLink>
       </StyledTD>
+      <StyledTDTextLeft>#{props[0]}</StyledTDTextLeft>
       <StyledTDTextLeft>
-        #{props[0]}
-      </StyledTDTextLeft>
-      <StyledTDTextLeft>
-        <Link
-          to={{
-            pathname: `/asset/${asset.id}`,
-            state: { state: props.state },
-          }}
-        >
-          {`${asset.name.substring(0, 20)}${(asset.name.length > 20 ? '...' : '')}`}
-        </Link>
+        <AssetLink asset={asset.id} state={props.state} >
+          {`${asset.name.substring(0, 20)}${
+            asset.name.length > 20 ? '...' : ''
+          }`}
+        </AssetLink>
       </StyledTDTextLeft>
       <StyledTDTextLeft>
         <Link

--- a/app/components/AssetLink/index.jsx
+++ b/app/components/AssetLink/index.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ *
+ * @param asset
+ * @param state
+ * @returns {*}
+ * @constructor
+ */
+export default function AssetLink({ asset, state, children, basepath }) {
+  const basepathUrl = basepath || '/asset';
+
+  const link = asset ? (
+    <Link
+      to={{
+        pathname: `${basepathUrl}/${asset}`,
+        state: { state },
+      }}
+    >
+      { children }
+    </Link>
+  ) : (
+    <div>
+      { children }
+    </div>
+  );
+
+  return link;
+}

--- a/app/components/AssetLink/tests/index.test.js
+++ b/app/components/AssetLink/tests/index.test.js
@@ -1,0 +1,10 @@
+// import React from 'react';
+// import { shallow } from 'enzyme';
+
+// import AssetLink from '../index';
+
+describe('<AssetLink />', () => {
+  it('Expect to have unit tests specified', () => {
+    expect(true).toEqual(false);
+  });
+});

--- a/app/components/AssetLogo/index.jsx
+++ b/app/components/AssetLogo/index.jsx
@@ -34,26 +34,27 @@ const WarningTooltip = styled(UncontrolledTooltip).attrs({
 `;
 
 function AssetLogo({ asset, prop, className, style}) {
-  const id = `id${Date.now()}${prop}`;
+  const id = `id${Date.now()}${prop ? prop : ''}`;
   const logo = getLogo(prop, asset);
   const hasWarning = some(asset.flags, (value, key) => key !== 'registered' && value);
 
   const Tooltip = hasWarning ? WarningTooltip : UncontrolledTooltip;
   const tooltipText = hasWarning ? 'Warning!' : `#${prop}: ${asset.name}`;
+  const CurrentTooltip =<Tooltip placement="top-end" target={id}>
+    {tooltipText}
+  </Tooltip>;
 
   return (
     <span>
       <IMGLogo src={logo} alt={asset.name} id={id} className={className} style={style}/>
-      <Tooltip placement="top-end" target={id}>
-        {tooltipText}
-      </Tooltip>
+      { CurrentTooltip }
     </span>
   );
 }
 
 AssetLogo.propTypes = {
   asset: PropTypes.object.isRequired,
-  prop: PropTypes.any.isRequired,
+  // prop: PropTypes.any.isRequired,
 };
 
 export default AssetLogo;

--- a/app/components/BlockList/index.jsx
+++ b/app/components/BlockList/index.jsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom';
 import { startFetch } from 'components/Token/actions';
 import { makeSelectProperty } from 'components/Token/selectors';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import ColoredHash from 'components/ColoredHash';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
@@ -139,16 +140,11 @@ class BlockList extends React.PureComponent {
       const logos = Object.keys(block.value.details).map((prop, idx) => {
         const key = `id${block.block}${prop}`;
         const asset = this.props.properties(prop);
+
         return (
-          <Link
-            key={key}
-            to={{
-              pathname: `/asset/${prop}`,
-              state: { state: this.props.state },
-            }}
-          >
+          <AssetLink key={key} asset={prop} state={this.props.state}>
             <AssetLogo asset={asset} prop={prop} style={{width: '2rem', height: '2rem'}}/>
-          </Link>
+          </AssetLink>
         );
       });
       return logos;

--- a/app/components/CrowdsaleInfo/index.jsx
+++ b/app/components/CrowdsaleInfo/index.jsx
@@ -9,12 +9,12 @@ import PropTypes from 'prop-types';
 import { routeActions } from 'redux-simple-router';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { Link } from 'react-router-dom';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 
 import styled from 'styled-components';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 
 const StyledTD = styled.td.attrs({
   className: 'align-middle',
@@ -26,62 +26,77 @@ const StyledTDTextLeft = styled(StyledTD).attrs({
   white-space: pre-wrap;
 `;
 
-class CrowdsaleInfo extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+class CrowdsaleInfo extends React.PureComponent {
+  // eslint-disable-line react/prefer-stateless-function
   render() {
+    
     return (
       <tr>
         <StyledTD>
-          <Link
-            to={{
-              pathname: `/crowdsale/${this.props.propertyid}`,
-              state: { state: this.props.state },
-            }}
+          <AssetLink
+            asset={this.props.propertyid}
+            state={this.props.state}
+            basepath="/crowdsale"
           >
             <AssetLogo
               asset={this.props}
               prop={this.props.propertyid}
-              style={{width: '4rem', height: '4rem'}}
+              style={{
+                width: '4rem',
+                height: '4rem',
+              }}
             />
-          </Link>
+          </AssetLink>
         </StyledTD>
         <StyledTDTextLeft>
-          <Link
-            to={{
-              pathname: `/crowdsale/${this.props.propertyid}`,
-              state: { state: this.props.state },
-            }}
+          <AssetLink
+            asset={this.props.propertyid}
+            state={this.props.state}
+            basepath="/crowdsale"
           >
             {this.props.name}
             <br/>
             {`(#${this.props.propertyid})`}
-          </Link>
+          </AssetLink>
         </StyledTDTextLeft>
         <StyledTDTextLeft>
-          <Link
-            to={{
-              pathname: `/asset/${this.props.propertyiddesired}`,
-              state: { state: this.props.state },
-            }}
+          <AssetLink
+            asset={this.props.propertyiddesired}
+            state={this.props.state}
           >
             {this.props.propertydesired.name}
             <br/>
             {`(#${this.props.propertyiddesired})`}
-          </Link>
+          </AssetLink>
         </StyledTDTextLeft>
         <StyledTDTextLeft>
-          <SanitizedFormattedNumber value={this.props.tokensperunit} forceDecimals={true}/>
+          <SanitizedFormattedNumber
+            value={this.props.tokensperunit}
+            forceDecimals
+          />
         </StyledTDTextLeft>
         <StyledTDTextLeft>
           <span>
-            <FormattedUnixDateTime datetime={this.props.deadline} useSeconds={false}/>
+            <FormattedUnixDateTime
+              datetime={this.props.deadline}
+              useSeconds={false}
+            />
           </span>
         </StyledTDTextLeft>
         <StyledTDTextLeft>
-          <SanitizedFormattedNumber value={this.props.totaltokens} fractionDigits={8}/>
+          <SanitizedFormattedNumber
+            value={this.props.totaltokens}
+            fractionDigits={8}
+          />
         </StyledTDTextLeft>
         <StyledTDTextLeft>
-          <a className="btn btn-primary" target="_blank"
-             href={`https://www.omniwallet.org/assets/details/${this.props.propertyid}`}>
+          <a
+            className="btn btn-primary"
+            target="_blank"
+            href={`https://www.omniwallet.org/assets/details/${
+              this.props.propertyid
+              }`}
+          >
             Buy with
             <br/>
             Omniwallet
@@ -105,11 +120,14 @@ CrowdsaleInfo.propTypes = {
 
 function mapDispatchToProps(dispatch) {
   return {
-    changeRoute: (url) => dispatch(routeActions.push(url)),
+    changeRoute: url => dispatch(routeActions.push(url)),
     dispatch,
   };
 }
 
-const withConnect = connect(null, mapDispatchToProps);
+const withConnect = connect(
+  null,
+  mapDispatchToProps,
+);
 
 export default compose(withConnect)(CrowdsaleInfo);

--- a/app/components/CrowdsaleTransaction/index.jsx
+++ b/app/components/CrowdsaleTransaction/index.jsx
@@ -24,6 +24,7 @@ import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import ColoredHash from 'components/ColoredHash';
 import StatusConfirmation from 'components/StatusConfirmation';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 import './transaction.scss';
 
 const AddressWrapper = styled.div.attrs({
@@ -191,18 +192,13 @@ class CrowdsaleTransaction extends React.PureComponent { // eslint-disable-line 
       <div className="transation-result mx-auto text-center-down-md">
         <Row className="align-items-end pb-0">
           <Col sm="12" md="1">
-            <Link
-              to={{
-                pathname: `/asset/${txAsset.propertyid}`,
-                state: { state: this.props.state },
-              }}
-            >
+            <AssetLink asset={txAsset.propertyid} state={this.props.state}>
               <AssetLogo
                 asset={txAsset}
                 prop={txAsset.propertyid}
                 style={{width: '4rem', height: '4rem', marginRight: '7px'}}
               />
-            </Link>
+            </AssetLink>
           </Col>
           <Col sm="12" md="5">
             <Row className="d-flex flex-xs-column flex-center-down-md mb-2">

--- a/app/components/Token/index.jsx
+++ b/app/components/Token/index.jsx
@@ -14,6 +14,7 @@ import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 
 import styled from 'styled-components';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 import { startFetch } from './actions';
 
 const StyledTD = styled.td.attrs({
@@ -66,38 +67,23 @@ class Token extends React.PureComponent {
     return (
       <tr>
         <StyledTD style={{ width: '56px' }}>
-          <Link
-            to={{
-              pathname: `/asset/${this.props.id}`,
-              state: { state: this.props.state },
-            }}
-          >
+          <AssetLink asset={this.props.id} state={this.props.state}>
             <AssetLogo
               asset={this.props.propertyinfo}
               prop={this.props.id}
               style={{width: '4rem', height: '4rem'}}
             />
-          </Link>
+          </AssetLink>
         </StyledTD>
         <StyledTD className="text-truncate" style={{ paddingTop: '13px' }}>
-          <Link
-            to={{
-              pathname: `/asset/${this.props.id}`,
-              state: { state: this.props.state },
-            }}
-          >
+          <AssetLink asset={this.props.id} state={this.props.state}>
             {this.props.id}
-          </Link>
+          </AssetLink>
         </StyledTD>
         <StyledTD className="text-truncate" style={{ paddingTop: '13px' }}>
-          <Link
-            to={{
-              pathname: `/asset/${this.props.id}`,
-              state: { state: this.props.state },
-            }}
-          >
+          <AssetLink asset={this.props.id} state={this.props.state}>
             {this.getTokenName()}
-          </Link>
+          </AssetLink>
         </StyledTD>
         <StyledTD style={{ textAlign: 'right', paddingTop: '13px' }}>
           <strong>

--- a/app/components/Token/reducer.js
+++ b/app/components/Token/reducer.js
@@ -19,7 +19,7 @@ const propertyReducer = (state = initialState, action = {}) => {
     case LOAD_PROPERTY_ERROR: {
       return state
         .set('isFetching', false)
-        .set('lastFetched', 0)
+        .set('lastFetched', Date.now())
         .set('error', error);
     }
     case LOAD_PROPERTY: {

--- a/app/components/Token/saga.js
+++ b/app/components/Token/saga.js
@@ -24,7 +24,7 @@ function* fetchSingleProperty(action) {
     const state = yield select(st => st);
     const tokens = state.get('token').get('tokens');
 
-    if (!tokens.get(action.id.toString())) {
+    if (action.id && !tokens.get(action.id.toString())) {
       const property = yield call(fetchProperty, action.id);
 
       if (!property) {

--- a/app/components/Transaction/index.jsx
+++ b/app/components/Transaction/index.jsx
@@ -23,6 +23,7 @@ import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import ColoredHash from 'components/ColoredHash';
 import StatusConfirmation from 'components/StatusConfirmation';
+import AssetLink from 'components/AssetLink';
 import AssetLogo from 'components/AssetLogo';
 import getTransactionHeading from 'utils/getTransactionHeading';
 import './transaction.scss';
@@ -150,18 +151,13 @@ class Transaction extends React.PureComponent {
       <div className="transation-result mx-auto text-center-down-md">
         <Row className="align-items-end pb-0">
           <Col sm="12" md="1">
-            <Link
-              to={{
-                pathname: `/asset/${this.props.propertyid}`,
-                state: { state: this.props.state },
-              }}
-            >
+            <AssetLink asset={this.props.propertyid} state={this.props.state}>
               <AssetLogo
                 asset={{...this.props, name: this.props.propertyname }}
                 prop={this.props.propertyid}
                 style={{width: '4rem', height: '4rem', marginRight: '7px'}}
               />
-            </Link>
+            </AssetLink>
           </Col>
           <Col sm="12" md="5">
             <Row className="d-flex flex-xs-column flex-center-down-md mb-2">

--- a/app/components/TransactionInfo/index.jsx
+++ b/app/components/TransactionInfo/index.jsx
@@ -13,22 +13,14 @@ import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import { Link } from 'react-router-dom';
-import {
-  Card,
-  CardBody,
-  CardHeader,
-  CardText,
-  Col,
-  Collapse,
-  Row,
-  Table,
-} from 'reactstrap';
+import { Card, CardBody, CardHeader, CardText, Col, Collapse, Row, Table } from 'reactstrap';
 
 import TransactionAmount from 'components/TransactionAmount';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import StatusConfirmation from 'components/StatusConfirmation';
 import { makeSelectProperty } from 'components/Token/selectors';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 
 import { CONFIRMATIONS } from 'containers/Transactions/constants';
 import { API_URL_BASE } from 'containers/App/constants';
@@ -77,7 +69,7 @@ function TransactionInfo(props) {
     confirmed: CONFIRMATIONS,
   });
   const invalidReason =
-    props.confirmations === 0 ? '' : `Reason: ${props.invalidreason || ''}`;
+    props.confirmations === 0 ? '' : `Reason: ${props.invalidreason || 'invalid transaction'}`;
   const rawTransactionURL = `${API_URL_BASE}/transaction/tx/${props.txid}`;
 
   let warningMessage = null;
@@ -114,16 +106,11 @@ function TransactionInfo(props) {
       <tr>
         <td className="field">Property</td>
         <td>
-          <Link
-            to={{
-              pathname: `/asset/${props.propertyid}`,
-              state: { state: props.state },
-            }}
-          >
+          <AssetLink asset={props.propertyid} state={props.state}>
             <strong>
               {props.propertyname} &#40;#{props.propertyid}&#41;
             </strong>
-          </Link>
+          </AssetLink>
         </td>
       </tr>
     );
@@ -148,7 +135,7 @@ function TransactionInfo(props) {
         <td>
           <strong>
             <span id="lamount">
-              <SanitizedFormattedNumber value={props.bitcoindesired} /> BTC
+              <SanitizedFormattedNumber value={props.bitcoindesired}/> BTC
             </span>
           </strong>
         </td>
@@ -168,19 +155,17 @@ function TransactionInfo(props) {
             <thead>
             <tr>
               <th>
-                <Link
-                  to={{
-                    pathname: `/asset/${props.asset.propertyid}`,
-                    state: { state: props.state },
-                  }}
-                >
-                <AssetLogo
-                  asset={props.asset}
-                  prop={props.asset.propertyid}
-                  className="img-thumbnail"
-                  style={{width: '4rem', height: '4rem'}}
-                />
-                </Link>
+                <AssetLink asset={props.asset.propertyid} state={props.state}>
+                  <AssetLogo
+                    asset={props.asset}
+                    prop={props.asset.propertyid}
+                    className="img-thumbnail"
+                    style={{
+                      width: '4rem',
+                      height: '4rem',
+                    }}
+                  />
+                </AssetLink>
               </th>
               <th>
                 <h4>
@@ -226,16 +211,18 @@ function TransactionInfo(props) {
               <td className="field">{dtheader}</td>
               <td>
                   <span id="ldatetime">
-                    <FormattedUnixDateTime datetime={props.blocktime} />
+                    <FormattedUnixDateTime datetime={props.blocktime}/>
                   </span>
               </td>
             </tr>
+            {props.block &&
             <tr>
               <td className="field">In Block</td>
               <td>
                 <span id="lblocknum">{props.block}</span>
               </td>
             </tr>
+            }
             <tr>
               <td className="field" style={{ paddingTop: '12px' }}>
                 Status
@@ -318,7 +305,7 @@ function TransactionInfo(props) {
           </Table>
         </Col>
       </DetailRow>
-      <Row />
+      <Row/>
     </div>
   );
 }
@@ -345,6 +332,7 @@ function mapDispatchToProps(dispatch) {
     changeRoute: url => dispatch(routeActions.push(url)),
   };
 }
+
 const mapStateToProps = createStructuredSelector({
   properties: state => makeSelectProperty(state),
 });

--- a/app/containers/CrowdsaleDetail/index.jsx
+++ b/app/containers/CrowdsaleDetail/index.jsx
@@ -38,6 +38,7 @@ import LoadingIndicator from 'components/LoadingIndicator';
 import Timer from 'components/Timer';
 import ContainerBase from 'components/ContainerBase';
 import AssetLogo from 'components/AssetLogo';
+import AssetLink from 'components/AssetLink';
 import moment from 'moment/src/moment';
 
 // Icons
@@ -158,19 +159,14 @@ export class CrowdsaleDetail extends React.PureComponent {
                 <thead>
                   <tr>
                     <td className="border-top-0">
-                      <Link
-                        to={{
-                          pathname: `/asset/${crowdsale.propertyid}`,
-                          state: { state: this.props.state },
-                        }}
-                      >
+                      <AssetLink asset={crowdsale.propertyid} state={this.props.state}>
                         <AssetLogo
                           asset={crowdsale}
                           prop={crowdsale.propertyid}
                           className="img-thumbnail d-md-inline-block"
                           style={{width: '4rem', height: '4rem'}}
                         />
-                      </Link>
+                      </AssetLink>
                     </td>
                     <td className="border-top-0 align-bottom">
                       <h2 className="d-md-inline-block align-bottom mb-0">

--- a/app/containers/Search/index.jsx
+++ b/app/containers/Search/index.jsx
@@ -17,6 +17,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
+import getPropByTx from 'utils/getPropByTx';
 
 import Wallet from 'components/Wallet';
 import TransactionInfo from 'components/TransactionInfo';
@@ -25,7 +26,7 @@ import LoadingIndicator from 'components/LoadingIndicator';
 import ContainerBase from 'components/ContainerBase';
 
 import { startFetch } from 'components/Token/actions';
-import { makeSelectProperties, makeSelectProperty, makeSelectLoading } from 'components/Token/selectors';
+import { makeSelectLoading, makeSelectProperties, makeSelectProperty } from 'components/Token/selectors';
 
 import makeSelectSearch from './selectors';
 import searchReducer from './reducer';
@@ -68,7 +69,7 @@ export class Search extends React.Component {
 
     const loading = (
       <Container>
-        <LoadingIndicator />
+        <LoadingIndicator/>
       </Container>
     );
 
@@ -77,8 +78,9 @@ export class Search extends React.Component {
     }
 
     if (!isEmpty(this.props.search.tx.type)) {
-      const property = this.props.properties(this.props.search.tx.propertyid);
-      if(!property) return loading;
+      const property = getPropByTx(this.props.search.tx, this.props.properties);
+
+      if (!property) return loading;
       tx = <TransactionInfo {...this.props.search.tx} asset={property} />;
     }
 
@@ -107,7 +109,7 @@ export class Search extends React.Component {
       this.props.search.address.balance.length > 0
     ) {
       wallet = (
-        <Wallet {...this.props.search} addr={this.query} extra={walletlink()} />
+        <Wallet {...this.props.search} addr={this.query} extra={walletlink()}/>
       );
     }
 
@@ -115,28 +117,28 @@ export class Search extends React.Component {
       assets = (
         <Table responsive className="mt-1">
           <thead>
-            <tr>
-              <StyledAssetTH>
-                <h4 className="align-self-end text-sm-left">
-                  <strong className="d-block">Properties</strong>
-                </h4>
-              </StyledAssetTH>
-            </tr>
-            <StyledTR>
-              <StyledTH />
-              <StyledTH>ID</StyledTH>
-              <StyledTH>Name</StyledTH>
-              <StyledTH>Issuer</StyledTH>
-            </StyledTR>
+          <tr>
+            <StyledAssetTH>
+              <h4 className="align-self-end text-sm-left">
+                <strong className="d-block">Properties</strong>
+              </h4>
+            </StyledAssetTH>
+          </tr>
+          <StyledTR>
+            <StyledTH/>
+            <StyledTH>ID</StyledTH>
+            <StyledTH>Name</StyledTH>
+            <StyledTH>Issuer</StyledTH>
+          </StyledTR>
           </thead>
           <tbody>
-            {this.props.search.asset.map((x, idx) => (
-              <Asset
-                {...x}
-                changeRoute={this.props.changeRoute}
-                key={x[2] + idx}
-              />
-            ))}
+          {this.props.search.asset.map((x, idx) => (
+            <Asset
+              {...x}
+              changeRoute={this.props.changeRoute}
+              key={x[2] + idx}
+            />
+          ))}
           </tbody>
         </Table>
       );
@@ -174,7 +176,10 @@ export class Search extends React.Component {
           <Col sm>
             <h3>
               Showing results for:&nbsp;
-              <div className="d-md-inline d-block-down-md" style={{ overflow: 'auto', overflowY: 'hidden' }}>
+              <div className="d-md-inline d-block-down-md" style={{
+                overflow: 'auto',
+                overflowY: 'hidden',
+              }}>
                 <mark>{this.query}</mark>
               </div>
             </h3>

--- a/app/containers/TransactionDetail/index.jsx
+++ b/app/containers/TransactionDetail/index.jsx
@@ -14,6 +14,7 @@ import { Container } from 'reactstrap';
 import injectReducer from 'utils/injectReducer';
 import injectSaga from 'utils/injectSaga';
 import getWarningMessage from 'utils/getWarningMessage';
+import getPropByTx from 'utils/getPropByTx';
 
 import LoadingIndicator from 'components/LoadingIndicator';
 import TransactionInfo from 'components/TransactionInfo';
@@ -52,7 +53,8 @@ export class TransactionDetail extends React.Component { // eslint-disable-line 
       return loading;
     }
 
-    const property = this.props.properties(this.props.txdetail.transaction.propertyid);
+    const property = getPropByTx(this.props.txdetail.transaction, this.props.properties);
+    // const property = this.props.properties(this.props.txdetail.transaction.propertyid);
     if (!property) return loading;
 
     if (this.props.txdetail.transaction.notFound) {

--- a/app/utils/getLogo.js
+++ b/app/utils/getLogo.js
@@ -17,6 +17,8 @@ export default (id, propertyinfo = {}) => {
         logo = require('images/tokenreplaced.png');
       } else if (flags.registered) {
         logo = require(`images/token${id}.png`);
+      } else if (flags.invalid) {
+        logo = require(`images/tokenwarn.png`);
       }
     } else {
       logo = require(`images/token${id}.png`);

--- a/app/utils/getPropByTx.js
+++ b/app/utils/getPropByTx.js
@@ -1,0 +1,19 @@
+/**
+ * Get Property by transaction
+ * @param tx: transaction
+ * @param getProperty: fn() to get property details
+ * @returns {*}
+ */
+export default (tx, getProperty) => {
+  const property =
+    tx.valid && tx.propertyid
+      ? getProperty(tx.propertyid)
+      : {
+        ...tx,
+        flags: {
+          invalid: true,
+        },
+      };
+
+  return property;
+};


### PR DESCRIPTION
### Changes

+ add link to asset detail only when its id is present
+ added `AssetLink` component
+ added `getPropByTx` to get token details by transaction detail, this helper also avoid request token without id
+ improvement of `getLogo` helper to retrieve a warning token based on property flags
+ #refactoring to use new helper `getPropByTx`
+ #refactoring to use new component `AssetLink`
+ #fix only do token service request when its id is present
+ #fix set `lastFetched` on property loading
