### PR TITLE
Feat unconfirmed transactions

### DIFF
--- a/app/components/ExplorerLink/index.jsx
+++ b/app/components/ExplorerLink/index.jsx
@@ -35,7 +35,6 @@ const explorers = {
 };
 
 function ExplorerLink({ explorerId, tx }) {
-  debugger;
   const explorer = explorers[explorerId];
   const logo = require(`images/external_logos/logo-${explorer.name}.png`);
   const href = `${explorer.pathbase}${tx}`;

--- a/app/components/ListHeader/index.jsx
+++ b/app/components/ListHeader/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { FormattedMessage, FormattedPlural } from 'react-intl';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Col, Row } from 'reactstrap';
+import { Button, ButtonGroup, Col, Row } from 'reactstrap';
 
 class ListHeader extends React.PureComponent {
   // eslint-disable-line react/prefer-stateless-function
@@ -26,6 +26,7 @@ class ListHeader extends React.PureComponent {
 
     // const totalLabel = `${this.props.totalLabel || 'transaction'}${this.props.total > 1 ? 's' : ''}`;
     const countMessage = this.props.countMessage || this.props.message;
+
     return (
       <StyledRow className="text-center-down-sm pt-2 pb-2">
         <Col sm md={8}>
@@ -45,6 +46,10 @@ class ListHeader extends React.PureComponent {
               </small>
             )}
           </HeaderTitle>
+          &nbsp;
+          {this.props.extra &&
+          <div className="d-inline-block">{this.props.extra}</div>
+          }
         </Col>
         {this.props.children &&
           <Col sm>{this.props.children}</Col>

--- a/app/components/TransactionListHeader/index.jsx
+++ b/app/components/TransactionListHeader/index.jsx
@@ -34,7 +34,7 @@ class TransactionListHeader extends React.PureComponent { // eslint-disable-line
         message={(this.props.customHeader || messages.header)}
         countMessage={(this.props.count || messages.count)}
       >
-        <ButtonDropdown size="sm" isOpen={this.state.dropdownOpen} toggle={this.toggle} className="float-md-right">
+        <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle} className="float-md-right">
           <DropdownToggle disabled caret color="info" className="font-weight-light">
             <FormattedMessage {...messages.transactionTypes} />
           </DropdownToggle>

--- a/app/containers/Transactions/actions.js
+++ b/app/containers/Transactions/actions.js
@@ -98,8 +98,9 @@ export function setTransactionType(txType) {
  *
  * @return {object} An action object with a type of LOAD_TRANSACTIONS
  */
-export function loadUnconfirmed() {
+export function loadUnconfirmed(addr = null) {
   return {
     type: LOAD_UNCONFIRMED,
+    addr,
   };
 }

--- a/app/containers/Transactions/saga.js
+++ b/app/containers/Transactions/saga.js
@@ -10,8 +10,11 @@ import encoderURIParams from 'utils/encoderURIParams';
 import { transactionsLoaded, transactionsLoadingError } from './actions';
 import { makeSelectTransactions } from './selectors';
 
-export function* getUnconfirmed() {
-  const requestURL = `${API_URL_BASE}/transaction/unconfirmed`;
+export function* getUnconfirmed({ addr }) {
+  const requestURL = addr
+    ? `${API_URL_BASE}/transaction/unconfirmed/${addr}`
+    : `${API_URL_BASE}/transaction/unconfirmed`;
+
   try {
     const transactions = yield call(request, requestURL);
     yield put(transactionsLoaded(transactions.data, 1));

--- a/app/global-styles.js
+++ b/app/global-styles.js
@@ -51,9 +51,11 @@ injectGlobal`
   a:link,
   a:visited,
   a:hover,
-  a:active {
-    background-color: transparent; 
+  a:active { 
     text-decoration: none;
+    &:not(.btn){
+      background-color: transparent;
+    }
   }
   
   .table td, .table th {


### PR DESCRIPTION
### Changes

+ #fix display background only when the link doesn't have `.btn` css class
+ removed unused `debugger` declaration
+ #refactoring saga to support unconfirmed transactions request by address
+ added `Confirmed` & `Unconfirmed` options
+ refactoring `ListHeader` to support extra elements in title
+ changed Transaction Type dropdown size to fit with Header elements