### PR TITLE
Fix transaction detail page hang in loading spinner

### DIFF
--- a/app/containers/TransactionDetail/index.jsx
+++ b/app/containers/TransactionDetail/index.jsx
@@ -45,7 +45,7 @@ export function TransactionDetail(props) {
   }, [tx]);
 
   useEffect(() => {
-    if (!props.tokens.lastFetched) {
+    if (!props.tokens.lastFetched && !props.txdetail.loading && props.txdetail.transaction.propertyid) {
       props.getProperty(props.txdetail.transaction.propertyid);
     }
   }, [props.txdetail.loading]);


### PR DESCRIPTION
### Changes

+ prevent to fetch prop details before to transaction detail has loaded