### PR TITLE
Support to explore testnet environment

### DIFF
--- a/app/components/Asset/index.jsx
+++ b/app/components/Asset/index.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import StyledLink from 'components/StyledLink';
+import { getSufixURL } from 'utils/getLocationPath';
 import styled from 'styled-components';
 import AssetLogo from 'components/AssetLogo';
 import AssetLink from 'components/AssetLink';
@@ -54,7 +55,7 @@ function Asset(props) {
       <StyledTDTextLeft>
         <StyledLink
           to={{
-            pathname: `/address/${asset.issuer}`,
+            pathname: `${getSufixURL}/address/${asset.issuer}`,
             state: { state: props.state },
           }}
         >

--- a/app/components/AssetInfo/index.jsx
+++ b/app/components/AssetInfo/index.jsx
@@ -14,6 +14,7 @@ import StyledLink from 'components/StyledLink';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import { API_URL_BASE, FEATURE_ACTIVATION_TYPE_INT } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import normalizeURL from 'utils/normalizeURL';
 
 const StyledTD = styled.td.attrs({
@@ -23,7 +24,7 @@ const StyledTD = styled.td.attrs({
 `;
 
 function AssetInfo(asset) {
-  const rawAssetURL = `${API_URL_BASE}/property/${asset.propertyid}`;
+  const rawAssetURL = `${getSufixURL()}/property/${asset.propertyid}`;
 
   let tokenName;
   let propertyID;
@@ -152,7 +153,7 @@ function AssetInfo(asset) {
         <td>
           <StyledLink
             to={{
-              pathname: `/address/${asset.issuer}`,
+              pathname: `${getSufixURL()}/address/${asset.issuer}`,
               state: { state: asset.state },
             }}
           >

--- a/app/components/AssetLink/index.jsx
+++ b/app/components/AssetLink/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import StyledLink from 'components/StyledLink';
+import { getSufixURL } from 'utils/getLocationPath';
 
 /**
  *
@@ -9,17 +10,14 @@ import StyledLink from 'components/StyledLink';
  * @constructor
  */
 export default function AssetLink({ asset, children, basepath }) {
-  const basepathUrl = basepath || '/asset';
+  const basepathUrl = `${getSufixURL()}${basepath || '/asset'}`;
   const isBTC = asset === 0;
-  const link = asset || isBTC ? (
-    <StyledLink to={`${basepathUrl}/${asset}`}>
-      {children}
-    </StyledLink>
-  ) : (
-    <div>
-      {children}
-    </div>
-  );
-  
+  const link =
+    asset || isBTC ? (
+      <StyledLink to={`${basepathUrl}/${asset}`}>{children}</StyledLink>
+    ) : (
+      <div>{children}</div>
+    );
+
   return link;
 }

--- a/app/components/BlockList/index.jsx
+++ b/app/components/BlockList/index.jsx
@@ -13,10 +13,12 @@ import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
+import flatMap from 'lodash/flatMap';
 
 import { startFetch } from 'components/Token/actions';
 import AssetLogo from 'components/AssetLogo';
 import AssetLink from 'components/AssetLink';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import ColoredHash from 'components/ColoredHash';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
@@ -44,9 +46,9 @@ class BlockList extends React.PureComponent {
 
   getDistinctTokensFromBlockList(blocks) {
     const properties = Object.values(blocks)
-      .map(block => Object.keys(block.value.details))
-      .flat();
-    const distincts = [...new Set(properties)];
+      .map(block => Object.keys(block.value.details));
+      // .flat();
+    const distincts = [...new Set(flatMap(properties))];
     return distincts;
   }
 
@@ -181,7 +183,7 @@ class BlockList extends React.PureComponent {
               <td>
                 <StyledLink
                   to={{
-                    pathname: `/block/${block.block}`,
+                    pathname: `${getSufixURL()}/block/${block.block}`,
                     state: { state: this.props.state },
                   }}
                 >
@@ -226,7 +228,7 @@ class BlockList extends React.PureComponent {
               <td className="text-center">
                 <StyledLink
                   to={{
-                    pathname: `/block/${block.block}`,
+                    pathname: `${getSufixURL()}/block/${block.block}`,
                     state: { state: this.props.state },
                   }}
                 >

--- a/app/components/BlockPagination/index.jsx
+++ b/app/components/BlockPagination/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Row } from 'reactstrap';
 import styled from 'styled-components';
-
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import StyledA from 'components/StyledA';
 
 const H4 = styled.h4`
@@ -34,14 +34,14 @@ function BlockPagination({ block, latest }) {
     <Row>
       <Col>
         <H4>
-          <LinkPrevious href={`/block/${prevBlock}`}>
+          <LinkPrevious href={`${getSufixURL()}/block/${prevBlock}`}>
             &lt;&lt; Block {prevBlock}
           </LinkPrevious>
         </H4>
       </Col>
       <Col className="text-right">
         <H4>
-          <LinkNext href={`/block/${nextBlock}`}>
+          <LinkNext href={`${getSufixURL()}/block/${nextBlock}`}>
             Block {nextBlock} &gt;&gt;
           </LinkNext>
         </H4>

--- a/app/components/ClientSidePagination/index.jsx
+++ b/app/components/ClientSidePagination/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Row } from 'reactstrap';
 import styled from 'styled-components';
-
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import StyledA from 'components/StyledA';
 
 const H3 = styled.h3`
@@ -32,14 +32,14 @@ function ClientSidePagination({ idx, latest, base }) {
     <Row>
       <Col sm={{ size: 2, offset: 1 }}>
         <H3>
-          <LinkPrevious href={`/${base}/${parseInt(idx, 10) - 1}`}>
+          <LinkPrevious href={`${getSufixURL()}/${base}/${parseInt(idx, 10) - 1}`}>
             &lt;&lt; Prev
           </LinkPrevious>
         </H3>
       </Col>
       <Col sm={{ size: 2, offset: 6 }} className="text-right">
         <H3>
-          <LinkNext href={`/${base}/${1 + parseInt(idx, 10)}`}>
+          <LinkNext href={`${getSufixURL()}/${base}/${1 + parseInt(idx, 10)}`}>
             Next &gt;&gt;
           </LinkNext>
         </H3>

--- a/app/components/CrowdsaleInfo/index.jsx
+++ b/app/components/CrowdsaleInfo/index.jsx
@@ -15,6 +15,7 @@ import styled from 'styled-components';
 import AssetLogo from 'components/AssetLogo';
 import AssetLink from 'components/AssetLink';
 import StyledA from 'components/StyledA';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 const StyledTD = styled.td.attrs({
   className: 'align-middle',
@@ -29,7 +30,7 @@ const StyledTDTextLeft = styled(StyledTD).attrs({
 class CrowdsaleInfo extends React.PureComponent {
   // eslint-disable-line react/prefer-stateless-function
   render() {
-    
+
     return (
       <tr>
         <StyledTD>

--- a/app/components/CrowdsaleTransaction/index.jsx
+++ b/app/components/CrowdsaleTransaction/index.jsx
@@ -23,6 +23,7 @@ import AssetLink from 'components/AssetLink';
 import WrapperTx from 'components/WrapperTx';
 import WrapperTxDatetime from 'components/WrapperTxDatetime';
 import 'components/Transaction/transaction.scss';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import AddressWrapper from 'components/AddressWrapper';
 import StyledLink from 'components/StyledLink';
@@ -149,7 +150,7 @@ class CrowdsaleTransaction extends React.PureComponent {
               <WrapperTx>
                 <StyledLink
                   to={{
-                    pathname: `/tx/${this.props.txid}`,
+                    pathname: `${getSufixURL()}/tx/${this.props.txid}`,
                     state: { state: this.props.state },
                   }}
                 >
@@ -183,7 +184,7 @@ class CrowdsaleTransaction extends React.PureComponent {
               <StyledLink
                 className={statusCSSClass}
                 to={{
-                  pathname: `/tx/${this.props.txid}`,
+                  pathname: `${getSufixURL()}/tx/${this.props.txid}`,
                   state: { state: this.props.state },
                 }}
               >
@@ -202,7 +203,7 @@ class CrowdsaleTransaction extends React.PureComponent {
                       this.props.sendingaddress,
                     )}`}
                     to={{
-                      pathname: `/address/${this.props.sendingaddress}`,
+                      pathname: `${getSufixURL()}/address/${this.props.sendingaddress}`,
                       state: { state: this.props.state },
                     }}
                   >
@@ -236,7 +237,7 @@ class CrowdsaleTransaction extends React.PureComponent {
                   <StyledLink
                     className={addresscname}
                     to={{
-                      pathname: `/address/${this.props.referenceaddress}`,
+                      pathname: `${getSufixURL()}/address/${this.props.referenceaddress}`,
                       state: { state: this.props.state },
                     }}
                   >

--- a/app/components/ErrorBoundary/index.jsx
+++ b/app/components/ErrorBoundary/index.jsx
@@ -15,6 +15,7 @@ import styled from 'styled-components';
 import { BrowserRouter } from 'react-router-dom';
 import { makeSelectStatus } from 'components/ServiceBlock/selectors';
 import StyledLink from 'components/StyledLink';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import ContainerBase from 'components/ContainerBase';
 import moment from 'moment/src/moment';
 import isJSON from 'utils/isJSON';

--- a/app/components/ExodusTransaction/index.js
+++ b/app/components/ExodusTransaction/index.js
@@ -1,0 +1,165 @@
+/**
+ *
+ * ExodusTransaction
+ *
+ */
+
+import React from 'react';
+// import PropTypes from 'prop-types';
+// import styled from 'styled-components';
+
+import { FormattedMessage } from 'react-intl';
+import messages from './messages';
+
+function ExodusTransaction() {
+  return (
+    <div>
+      <div direction="vertical" className="sc-1fp9csv-0 clQqCp">
+        <div className="sc-1xo2hia-0 ooDhA">
+          <div width="50%" className="odi4cq-0 dMPYVC">
+            <div width="100px" className="ccso3i-0 hKpYDy"><span
+              className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx sc-1n72lkw-0 lhmHll" opacity="1">Hash</span></div>
+            <div width="calc(100% - 100px)" className="ccso3i-0 bmbfXL"><a
+              href="https://www.blockchain.com/btc/tx/734799979782b61da4b7cac145f3750ccde41f18770de591c7d3d2e85f76a25a"
+              className="sc-1r996ns-0 gzrtQD sc-1tbyx6t-1 kXxRxe iklhnl-0 boNhIO"
+              opacity="1">734799979782b61da4b7cac145f3750ccde41f18770de591c7d3d2e85f76a25a</a></div>
+          </div>
+          <div width="50%" className="odi4cq-0 dMPYVC">
+            <div width="100px" className="ccso3i-0 hKpYDy">
+              <div target="desktop" className="sc-197you3-0 bvHqAx"><span
+                className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx sc-1n72lkw-0 lhmHll" opacity="1">Date</span></div>
+            </div>
+            <div width="calc(100% - 100px)" className="ccso3i-0 bmbfXL">
+              <div className="kad8ah-0 kKDjc"><span className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                                                    opacity="1">2020-07-28 09:03</span></div>
+            </div>
+          </div>
+        </div>
+        <div className="sc-1xo2hia-0 ooDhA">
+          <div width="50%" className="odi4cq-0 dMPYVC">
+            <div width="100px" className="ccso3i-0 hKpYDy">
+              <div target="desktop" className="sc-197you3-0 bvHqAx"><span
+                className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx sc-1n72lkw-0 lhmHll" opacity="1">From</span></div>
+            </div>
+            <div width="calc(100% - 100px)" className="ccso3i-0 bmbfXL">
+              <div className="pc1med-0 jXEkEE">
+                <div className="pc1med-1 huGTnd">
+                  <div className="ge5wha-0 gPBsWw"><span
+                    className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                    opacity="1">1LgmqPpigz3Frj8zARocwujS7yvXko847h</span>
+                    <div className="ge5wha-1 hdwAPC"><span
+                      className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                      opacity="1">0.09519392 BTC</span><a
+                      href="https://www.blockchain.com/btc/tx/9a0010217a3a2a96b1a8361f93d7f7ed95b551f55ac5fa8e67e7e8c6a4c36f74"
+                      className="sc-1r996ns-0 gzrtQD sc-1tbyx6t-1 kXxRxe iklhnl-0 boNhIO" opacity="1">
+                      <div>
+                        <svg viewBox="0 0 496 512" className="sc-1pmbxjh-0 bvrqDT sc-1legmm2-0 fiBrDw" height="14px"
+                             selectable="1" width="14px">
+                          <path
+                            d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"></path>
+                        </svg>
+                      </div>
+                    </a></div>
+                  </div>
+                </div>
+                <div className="pc1med-2 iFMuja"></div>
+              </div>
+            </div>
+          </div>
+          <div width="50%" className="odi4cq-0 dMPYVC">
+            <div width="100px" className="ccso3i-0 hKpYDy">
+              <div target="desktop" className="sc-197you3-0 bvHqAx"><span
+                className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx sc-1n72lkw-0 lhmHll" opacity="1">To</span></div>
+              <div target="mobile" className="sc-197you3-0 ljbrSF">
+                <svg enable-background="new 0 0 32 32" height="32px" id="svg2" version="1.1" viewBox="0 0 32 32"
+                     width="32px" className="sc-1ub63u6-0 uRdJX">
+                  <g id="background">
+                    <rect fill="none" height="32" width="32"></rect>
+                  </g>
+                  <g id="arrow_x5F_full_x5F_right">
+                    <polygon points="16,2.001 16,10 2,10 2,22 16,22 16,30 30,16  "></polygon>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div width="calc(100% - 100px)" className="ccso3i-0 bmbfXL">
+              <div className="azsi2v-0 iOfeMf">
+                <div className="azsi2v-1 gkQXry">
+                  <div className="sc-19pxzmk-0 lhmncg"><span
+                    className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                    opacity="1">OP_RETURN</span><span
+                    className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                    opacity="1">0.00000000 BTC</span></div>
+                  <div className="sc-19pxzmk-0 lhmncg"><a
+                    href="https://www.blockchain.com/btc/address/15HgHk3vX8SF1EedQLPEXRNAhywyk64qA3"
+                    className="sc-1r996ns-0 gzrtQD sc-1tbyx6t-1 kXxRxe iklhnl-0 boNhIO"
+                    opacity="1">15HgHk3vX8SF1EedQLPEXRNAhywyk64qA3</a>
+                    <div className="sc-19pxzmk-1 cspEAW"><span
+                      className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                      opacity="1">0.00000546 BTC</span>
+                      <div>
+                        <svg viewBox="0 0 496 512" className="sc-1pmbxjh-0 cComos sc-1eth4zq-1 bCvdMP" height="14px"
+                             selectable="0" width="14px">
+                          <path
+                            d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"></path>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="sc-19pxzmk-0 lhmncg"><span
+                    className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                    opacity="1">1LgmqPpigz3Frj8zARocwujS7yvXko847h</span>
+                    <div className="sc-19pxzmk-1 cspEAW"><span
+                      className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                      opacity="1">0.09489438 BTC</span><a
+                      href="https://www.blockchain.com/btc/tx/5d1e03779b3f33888023331d81696291fee5d8cff4abf615918461a60191386c"
+                      className="sc-1r996ns-0 gzrtQD sc-1tbyx6t-1 kXxRxe iklhnl-0 boNhIO" opacity="1">
+                      <div>
+                        <svg viewBox="0 0 496 512" className="sc-1pmbxjh-0 bvrqDT sc-1eth4zq-0 bmWQqq" height="14px"
+                             selectable="1" width="14px">
+                          <path
+                            d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"></path>
+                        </svg>
+                      </div>
+                    </a></div>
+                  </div>
+                </div>
+                <div className="azsi2v-2 gGLePR"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="sc-1xo2hia-0 ooDhA">
+          <div width="50%" className="odi4cq-0 dMPYVC">
+            <div width="100px" className="ccso3i-0 hKpYDy"><span
+              className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx sc-1n72lkw-0 lhmHll" opacity="1">Fee</span></div>
+            <div width="calc(100% - 100px)" className="ccso3i-0 bmbfXL">
+              <div className="kad8ah-1 giMhWw"><span className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg"
+                                                     opacity="1">0.00029408 BTC</span><span
+                className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg" opacity="1">(114.875 sat/B - 28.719 sat/WU - 256 bytes)</span>
+              </div>
+            </div>
+          </div>
+          <div width="50%" className="odi4cq-0 dMPYVC">
+            <div width="100px" className="ccso3i-0 fWCAed">
+              <div target="desktop" className="sc-197you3-0 bvHqAx"><span
+                className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx sc-1n72lkw-0 lhmHll" opacity="1">Amount</span></div>
+            </div>
+            <div width="calc(100% - 100px)" className="ccso3i-0 gmtFME">
+              <div className="kad8ah-2 htQidj">
+                <div className="kad8ah-0 gsjnEH"><span
+                  className="sc-1ryi78w-0 gCzMgE sc-16b9dsl-1 kUAhZx u3ufsr-0 fGQJzg sc-85fclk-0 kcLHOb" opacity="1">-0.00029954 BTC</span>
+                </div>
+                <div><span className="sc-1rs1xpb-0 gcloxF sc-1mclc94-0 s24bmm-0 yZDdO">2 Confirmations</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ExodusTransaction.propTypes = {};
+
+export default ExodusTransaction;

--- a/app/components/ExodusTransaction/messages.js
+++ b/app/components/ExodusTransaction/messages.js
@@ -1,0 +1,16 @@
+/*
+ * ExodusTransaction Messages
+ *
+ * This contains all the text for the ExodusTransaction component.
+ */
+
+import { defineMessages } from 'react-intl';
+
+export const scope = 'app.components.ExodusTransaction';
+
+export default defineMessages({
+  header: {
+    id: `${scope}.header`,
+    defaultMessage: 'This is the ExodusTransaction component!',
+  },
+});

--- a/app/components/ExodusTransaction/tests/index.test.js
+++ b/app/components/ExodusTransaction/tests/index.test.js
@@ -1,0 +1,47 @@
+/**
+ *
+ * Tests for ExodusTransaction
+ *
+ * @see https://github.com/react-boilerplate/react-boilerplate/tree/master/docs/testing
+ *
+ */
+
+import React from 'react';
+import { render } from 'react-testing-library';
+import { IntlProvider } from 'react-intl';
+// import 'jest-dom/extend-expect'; // add some helpful assertions
+
+import ExodusTransaction from '../index';
+import { DEFAULT_LOCALE } from '../../../i18n';
+
+describe('<ExodusTransaction />', () => {
+  it('Expect to not log errors in console', () => {
+    const spy = jest.spyOn(global.console, 'error');
+    render(
+      <IntlProvider locale={DEFAULT_LOCALE}>
+        <ExodusTransaction />
+      </IntlProvider>,
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('Expect to have additional unit tests specified', () => {
+    expect(true).toEqual(false);
+  });
+
+  /**
+   * Unskip this test to use it
+   *
+   * @see {@link https://jestjs.io/docs/en/api#testskipname-fn}
+   */
+  it.skip('Should render and match the snapshot', () => {
+    const {
+      container: { firstChild },
+    } = render(
+      <IntlProvider locale={DEFAULT_LOCALE}>
+        <ExodusTransaction />
+      </IntlProvider>,
+    );
+    expect(firstChild).toMatchSnapshot();
+  });
+});

--- a/app/components/FooterLinks/index.jsx
+++ b/app/components/FooterLinks/index.jsx
@@ -12,7 +12,7 @@ import { Col } from 'reactstrap';
 import StyledLink from 'components/StyledLink';
 import FooterRow from 'components/FooterRow';
 import GreenArrowForward from 'components/GreenArrowForward';
-
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import messages from './messages';
 
 const Div = styled.div.attrs({
@@ -29,7 +29,7 @@ function FooterLinks(props) {
             <StyledLink
               onClick={window.location.reload}
               to={{
-                pathname: `/blocks`,
+                pathname: `${getSufixURL()}/blocks`,
                 state: { state: {} },
               }}
               key={Date.now()}
@@ -46,7 +46,7 @@ function FooterLinks(props) {
             <StyledLink
               onClick={window.location.reload}
               to={{
-                pathname: `/transactions/unconfirmed`,
+                pathname: `${getSufixURL()}/transactions/unconfirmed`,
                 state: {},
               }}
               key={Date.now()}

--- a/app/components/Header/index.jsx
+++ b/app/components/Header/index.jsx
@@ -28,6 +28,8 @@ import {
   UncontrolledDropdown,
 } from 'reactstrap';
 
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
+
 const IMG = styled.img`
   padding-bottom: 3px;
   padding-right: 9px;
@@ -93,10 +95,10 @@ class Header extends React.PureComponent {
                   </DropdownToggle>
                   <DropdownMenu right>
                     <DropdownItem>
-                      <NavLink href={`/properties/${ECOSYSTEM_PROD_NAME.toLowerCase()}`} >Production</NavLink>
+                      <NavLink href={`${getSufixURL()}/properties/${ECOSYSTEM_PROD_NAME.toLowerCase()}`} >Production</NavLink>
                     </DropdownItem>
                     <DropdownItem>
-                      <NavLink href={`/properties/${ECOSYSTEM_TEST_NAME.toLowerCase()}`} >Test</NavLink>
+                      <NavLink href={`${getSufixURL()}/properties/${ECOSYSTEM_TEST_NAME.toLowerCase()}`} >Test</NavLink>
                     </DropdownItem>
                   </DropdownMenu>
                 </UncontrolledDropdown>
@@ -106,10 +108,10 @@ class Header extends React.PureComponent {
                   </DropdownToggle>
                   <DropdownMenu right>
                     <DropdownItem>
-                      <NavLink href={`/crowdsales/${ECOSYSTEM_PROD_NAME.toLowerCase()}`}>Production</NavLink>
+                      <NavLink href={`${getSufixURL()}/crowdsales/${ECOSYSTEM_PROD_NAME.toLowerCase()}`}>Production</NavLink>
                     </DropdownItem>
                     <DropdownItem>
-                      <NavLink href={`/crowdsales/${ECOSYSTEM_TEST_NAME.toLowerCase()}`}>Test</NavLink>
+                      <NavLink href={`${getSufixURL()}/crowdsales/${ECOSYSTEM_TEST_NAME.toLowerCase()}`}>Test</NavLink>
                     </DropdownItem>
                   </DropdownMenu>
                 </UncontrolledDropdown>
@@ -122,7 +124,10 @@ class Header extends React.PureComponent {
                     {/*  <NavLink href="/exchange">Exchange</NavLink>*/}
                     {/*</DropdownItem>*/}
                     <DropdownItem>
-                      <NavLink href="/activations">Feature Activations</NavLink>
+                      <NavLink href="/testnet/">Testnet</NavLink>
+                    </DropdownItem>
+                    <DropdownItem>
+                      <NavLink href={`${getSufixURL()}/activations`}>Feature Activations</NavLink>
                     </DropdownItem>
                     <DropdownItem>
                       <NavLink href="http://www.omnilayer.org/#GetStarted" target="_blank">Wallets</NavLink>

--- a/app/components/NoOmniBlockTransactions/index.jsx
+++ b/app/components/NoOmniBlockTransactions/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import StyledLink from 'components/StyledLink';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import messages from './messages';
 
 const StyledH3 = styled.h3`
@@ -42,7 +43,7 @@ function NoOmniBlockTransactions(props={useDefaults: true}) {
       <p className="text-center">
         <StyledLink
           to={{
-            pathname: `/blocks`,
+            pathname: `${getSufixURL()}/blocks`,
             state: { state: props.state },
           }}
         >

--- a/app/components/ServiceBlock/saga.js
+++ b/app/components/ServiceBlock/saga.js
@@ -2,11 +2,12 @@ import { call, put, take } from 'redux-saga/effects';
 import request from 'utils/request';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { LOAD_STATUS } from './constants';
 import { updateFetch } from './actions';
 
 function* fetchStatus() {
-  const requestURL = `${API_URL_BASE}/system/status`;
+  const requestURL = `${getLocationPath()}/system/status`;
   const status = yield call(request, requestURL);
   yield put(updateFetch(status));
 }

--- a/app/components/Token/saga.js
+++ b/app/components/Token/saga.js
@@ -5,6 +5,7 @@ import encoderURIParams from 'utils/encoderURIParams';
 import chunk from 'lodash/chunk';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { LOAD_MANY_PROPERTIES, LOAD_PROPERTY, LOAD_PROPERTY_DEEP, FETCHING_PROPERTY } from './constants';
 import { cancelFetch, updateFetch, updateFetchMany, startFetch } from './actions';
 import { getTokens } from './selectors';
@@ -74,7 +75,7 @@ function* fetchPropertyDeep(action) {
 }
 
 function* fetchProperty(propertyId) {
-  const requestURL = `${API_URL_BASE}/property/${propertyId}`;
+  const requestURL = `${getLocationPath()}/property/${propertyId}`;
   const property = yield call(request, requestURL);
 
   yield put(updateFetch(property));
@@ -103,7 +104,7 @@ function* fetchManyProperties(action) {
   yield delay(1000);
   // load token if is still not requested
 
-  const requestURL = `${API_URL_BASE}/property/bulk`;
+  const requestURL = `${getLocationPath()}/property/bulk`;
   const state = yield select(st => st);
   const { token } = state;
 

--- a/app/components/Transaction/index.jsx
+++ b/app/components/Transaction/index.jsx
@@ -19,6 +19,7 @@ import AssetLink from 'components/AssetLink';
 import AssetLogo from 'components/AssetLogo';
 import WrapperLink from 'components/WrapperLink';
 import getTransactionHeading from 'utils/getTransactionHeading';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import './transaction.scss';
 
 import AddressWrapper from 'components/AddressWrapper';
@@ -147,7 +148,7 @@ class Transaction extends React.PureComponent {
               <WrapperTx>
                 <StyledLink
                   to={{
-                    pathname: `/tx/${this.props.txid}`,
+                    pathname: `${getSufixURL()}/tx/${this.props.txid}`,
                     state: { state: this.props.state },
                   }}
                 >
@@ -182,7 +183,7 @@ class Transaction extends React.PureComponent {
                 className={statusCSSClass}
                 style={{ cursor: 'default' }}
                 to={{
-                  pathname: `/tx/${this.props.txid}`,
+                  pathname: `${getSufixURL()}/tx/${this.props.txid}`,
                   state: { state: this.props.state },
                 }}
                 id={invalidid}
@@ -207,7 +208,7 @@ class Transaction extends React.PureComponent {
                 <WrapperLink>
                   <StyledLink
                     className={this.getHighlightIfOwner(this.props.sendingaddress)}
-                    to={`/address/${this.props.sendingaddress}`}
+                    to={`${getSufixURL()}/address/${this.props.sendingaddress}`}
                   >
                     {this.props.sendingaddress}
                   </StyledLink>
@@ -244,7 +245,7 @@ class Transaction extends React.PureComponent {
                 <WrapperLink>
                   <StyledLink
                     className={addresscname}
-                    to={`/address/${this.props.referenceaddress}`}
+                    to={`${getSufixURL()}/address/${this.props.referenceaddress}`}
                   >
                     {this.props.referenceaddress}
                   </StyledLink>

--- a/app/components/TransactionAmount/index.jsx
+++ b/app/components/TransactionAmount/index.jsx
@@ -15,6 +15,8 @@ import AssetLogo from 'components/AssetLogo';
 import AssetLink from 'components/AssetLink';
 import StyledA from 'components/StyledA';
 
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
+
 class TransactionAmount extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
     super(props);

--- a/app/components/TransactionInfo/index.jsx
+++ b/app/components/TransactionInfo/index.jsx
@@ -26,6 +26,7 @@ import { EXTERNAL_EXPLORER_BLOCKCHAIR } from 'components/ExplorerLink/constants'
 
 import { CONFIRMATIONS } from 'containers/Transactions/constants';
 import { API_URL_BASE, FEATURE_ACTIVATION_TYPE_INT } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import getTransactionHeading from 'utils/getTransactionHeading';
 
 const StyledCard = styled(Card)`
@@ -65,7 +66,7 @@ function TransactionInfo(props) {
   });
   const invalidReason =
     props.confirmations === 0 ? '' : `Reason: ${props.invalidreason || 'invalid transaction'}`;
-  const rawTransactionURL = `${API_URL_BASE}/transaction/tx/${props.txid}`;
+  const rawTransactionURL = `${getSufixURL()}/transaction/tx/${props.txid}`;
 
   let warningMessage = null;
   let dtheader;
@@ -204,7 +205,7 @@ function TransactionInfo(props) {
               <td>
                 <StyledLink
                   to={{
-                    pathname: `/address/${props.sendingaddress}`,
+                    pathname: `${getSufixURL()}/address/${props.sendingaddress}`,
                     state: { state: props.state },
                   }}
                 >
@@ -218,7 +219,7 @@ function TransactionInfo(props) {
               <td>
                 <StyledLink
                   to={{
-                    pathname: `/address/${recipient}`,
+                    pathname: `${getSufixURL()}/address/${recipient}`,
                     state: { state: props.state },
                   }}
                 >
@@ -241,7 +242,7 @@ function TransactionInfo(props) {
               <td>
                 <StyledLink
                   to={{
-                    pathname: `/block/${props.block}`,
+                    pathname: `${getSufixURL()}/block/${props.block}`,
                     state: { state: props.state },
                   }}
                 >

--- a/app/containers/Activations/index.jsx
+++ b/app/containers/Activations/index.jsx
@@ -23,6 +23,7 @@ import ContainerBase from 'components/ContainerBase';
 import ListHeader from 'components/ListHeader';
 import { useInjectSaga } from 'utils/injectSaga';
 import { useInjectReducer } from 'utils/injectReducer';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import { makeSelectActivations } from './selectors';
 import messages from './messages';
@@ -107,7 +108,7 @@ export function Activations(props) {
               <WrapperTx>
                 <StyledLink
                   to={{
-                    pathname: `/tx/${activation.txhash}`,
+                    pathname: `${getSufixURL()}/tx/${activation.txhash}`,
                     state: { state: props.state },
                   }}
                 >

--- a/app/containers/Activations/saga.js
+++ b/app/containers/Activations/saga.js
@@ -1,12 +1,13 @@
 import { call, put, take } from 'redux-saga/effects';
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import request from 'utils/request';
 
 import { LOAD_ACTIVATIONS } from './constants';
 import { activationsLoaded } from './actions';
 
 export function* getActivations() {
-  const requestURL = `${API_URL_BASE}/system/featureactivations`;
+  const requestURL = `${getLocationPath()}/system/featureactivations`;
   const activations = yield call(request, requestURL);
   yield put(activationsLoaded(activations));
 }

--- a/app/containers/AddressDetail/saga.js
+++ b/app/containers/AddressDetail/saga.js
@@ -1,10 +1,10 @@
-import { all, call, put, take } from 'redux-saga/effects';
+import { call, put, take } from 'redux-saga/effects';
 import { LOAD_ADDRESS } from 'containers/AddressDetail/constants';
 import {
-  API_URL_BASE,
   API_URL_BLOCKCHAIN_BTC_BALANCE,
   FN_API_URL_BLOCKCHAIR_BTC_BALANCE,
 } from 'containers/App/constants';
+import getLocationPath from 'utils/getLocationPath';
 import { updateFetch } from 'components/Token/actions';
 import { addressLoaded } from 'containers/AddressDetail/actions';
 import encoderURIParams from 'utils/encoderURIParams';
@@ -13,7 +13,7 @@ import request from 'utils/request';
 import isNil from 'lodash/isNil';
 
 export function* getAddress({ addr }) {
-  const requestURL = `${API_URL_BASE}/address/addr`;
+  const requestURL = `${getLocationPath()}/address/addr`;
 
   const body = encoderURIParams({ addr });
   const options = {
@@ -26,10 +26,17 @@ export function* getAddress({ addr }) {
 
   // get BTC balance from blockchain.info for the given wallet
   const urlBTCBalance = `${API_URL_BLOCKCHAIN_BTC_BALANCE}${addr}`;
-  let [wallet, btcBalance] = yield all([
-    call(request, requestURL, options),
-    call(request, urlBTCBalance),
-  ]);
+
+  const wallet = yield call(request, requestURL, options);
+  let btcBalance;
+
+  try {
+    btcBalance = yield* call(request, urlBTCBalance);
+  } catch {}
+  // let [wallet, btcBalance] = yield all([
+  //   call(request, requestURL, options),
+  //   call(request, urlBTCBalance),
+  // ]);
 
   /**
    // use btc balance from blockchain.info response
@@ -37,20 +44,21 @@ export function* getAddress({ addr }) {
    const walletBTCBalance = wallet.balance.find(x => x.id == 0);
    if (walletBTCBalance) walletBTCBalance.value = btcBalanceValue;
    * */
-
   let btcBalanceValue;
 
   // if there is a valid response use btc balance from blockchain.info response
-  if (btcBalance[addr] && !isNil(btcBalance[addr].final_balance)) {
+  if (btcBalance && btcBalance[addr] && !isNil(btcBalance[addr].final_balance)) {
     btcBalanceValue = btcBalance[addr].final_balance;
   } else {
     // if blockchain.info retrieves an error try with blockchair
     const urlBTCBalanceAlternative = FN_API_URL_BLOCKCHAIR_BTC_BALANCE({
       address: addr,
     });
-    btcBalance = yield call(request, urlBTCBalanceAlternative);
-    // use btc balance from blockchair.com response
-    btcBalanceValue = btcBalance.data[addr].address.balance;
+    try {
+      btcBalance = yield* call(request, urlBTCBalanceAlternative);
+      // use btc balance from blockchair.com response
+      btcBalanceValue = btcBalance.data[addr].address.balance;
+    } catch {}
   }
 
   const walletBTCBalance = wallet.balance.find(x => x.id == 0);

--- a/app/containers/AddressDetail/tests/saga.test.js
+++ b/app/containers/AddressDetail/tests/saga.test.js
@@ -8,6 +8,7 @@ import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import {
   addressLoaded,
   addressLoadingError,
@@ -59,7 +60,7 @@ describe('getAddress Saga', () => {
     };
 
     const saga = testSaga(getAddress, { addr });
-    const url = `${API_URL_BASE}/address/addr`;
+    const url = `${getLocationPath()}/address/addr`;
     const body = encoderURIParams({ addr });
     const options = {
       method: 'POST',

--- a/app/containers/App/constants.js
+++ b/app/containers/App/constants.js
@@ -11,6 +11,7 @@
 import generateTemplate from 'utils/generateTemplate';
 
 export const API_URL_BASE = 'https://api.omniexplorer.info/v1';
+export const API_TESTNET_URL_BASE = 'https://testnetapi.omniexplorer.info/v1';
 export const API_URL_BLOCKCHAIN_BTC_BALANCE = 'https://blockchain.info/balance?cors=true&active=';
 export const FN_API_URL_BLOCKCHAIR_BTC_BALANCE = (data)=> generateTemplate`https://api.blockchair.com/bitcoin/dashboards/address/${'address'}?state=latest&limit=0,0`(data);
 export const FN_API_URL_BLOCKCHAIN_ADDR = (data)=> generateTemplate`https://blockchain.info/rawaddr/${'address'}?cors=true&limit=${'limit'}&offset=${'offset'}`(data);

--- a/app/containers/App/index.jsx
+++ b/app/containers/App/index.jsx
@@ -105,45 +105,98 @@ export function App({
       <ErrorBoundary>
         <Switch>
           <Route exact path="/:block(\d+)?" component={HomePage} />
+          <Route exact path="/testnet/:block(\d+)?" component={HomePage} />
+
           <Route path="/tx/:tx" component={TransactionDetail} />
+          <Route path="/testnet/tx/:tx" component={TransactionDetail} />
+
           <Route path="/transactions/unconfirmed" component={Transactions} />
+          <Route path="/testnet/transactions/unconfirmed" component={Transactions} />
+
           <Route
             path="/address/:address/:page(\d+)?"
             component={AddressDetail}
             key={location.pathname}
           />
           <Route
+            path="/testnet/address/:address/:page(\d+)?"
+            component={AddressDetail}
+            key={location.pathname}
+          />
+
+          <Route
             path="/search/:query"
             component={Search}
             key={location.pathname}
           />
+          <Route
+            path="/testnet/search/:query"
+            component={Search}
+            key={location.pathname}
+          />
+
           <Route
             path="/properties/:query"
             component={Properties}
             key={location.pathname}
           />
           <Route
+            path="/testnet/properties/:query"
+            component={Properties}
+            key={location.pathname}
+          />
+
+          <Route
             path="/asset/:propertyid(\d+)"
             component={AssetDetail}
             key={location.pathname}
           />
+          <Route
+            path="/testnet/asset/:propertyid(\d+)"
+            component={AssetDetail}
+            key={location.pathname}
+          />
+
           <Route exact path="/crowdsales/:ecosystem" component={Crowdsales} />
+          <Route exact path="/testnet/crowdsales/:ecosystem" component={Crowdsales} />
+
           <Route
             path="/crowdsale/:crowdsaleid(\d+)"
             component={CrowdsaleDetail}
             key={location.pathname}
           />
           <Route
+            path="/testnet/crowdsale/:crowdsaleid(\d+)"
+            component={CrowdsaleDetail}
+            key={location.pathname}
+          />
+
+          <Route
             exact
             path="/block/:block(\d+)"
             component={BlockDetail}
             key={location.pathname}
           />
+          <Route
+            exact
+            path="/testnet/block/:block(\d+)"
+            component={BlockDetail}
+            key={location.pathname}
+          />
+
           <Route exact path="/promote" component={Promote} />
+          <Route exact path="/testnet/promote" component={Promote} />
+
           <Route exact path="/submitfeedback" component={Feedback} />
+          <Route exact path="/testnet/submitfeedback" component={Feedback} />
+
           {/*<Route exact path="/analytics" component={HistoryChart} />*/}
           <Route exact path="/blocks/:block(\d+)?" component={FullBlockList} />
+          <Route exact path="/testnet/blocks/:block(\d+)?" component={FullBlockList} />
+
           <Route exact path="/activations" component={Activations} />
+          <Route exact path="/testnet/activations" component={Activations} />
+
           {/*<Route exact path="/exchange" component={Exchange} />*/}
           <Route path="" component={NotFoundPage} />
           <Route component={NotFoundPage} />

--- a/app/containers/AssetDetail/index.jsx
+++ b/app/containers/AssetDetail/index.jsx
@@ -21,6 +21,7 @@ import ContainerBase from 'components/ContainerBase';
 import AssetLogo from 'components/AssetLogo';
 
 import getWarningMessage from 'utils/getWarningMessage';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 const DetailRow = styled(Row)`
   margin-top: 2rem;
@@ -92,7 +93,7 @@ export function AssetDetail(props) {
                     <span>created by &nbsp;</span>
                     <StyledLink
                       to={{
-                        pathname: `/tx/${asset.creationtxid}`,
+                        pathname: `${getSufixURL()}/tx/${asset.creationtxid}`,
                         state: { state: props.state },
                       }}
                     >

--- a/app/containers/BlockDetail/index.jsx
+++ b/app/containers/BlockDetail/index.jsx
@@ -34,6 +34,7 @@ import { useInjectSaga } from 'utils/injectSaga';
 import { useInjectReducer } from 'utils/injectReducer';
 import isEmpty from 'lodash/isEmpty';
 import getMaxPagesByMedia from 'utils/getMaxPagesByMedia';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import { makeSelectStatus } from 'components/ServiceBlock/selectors';
 import FooterLinks from 'components/FooterLinks';

--- a/app/containers/BlockDetail/saga.js
+++ b/app/containers/BlockDetail/saga.js
@@ -1,15 +1,16 @@
 import { call, put, take } from 'redux-saga/effects';
 import { LOAD_BLOCK } from 'containers/BlockDetail/constants';
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { blockLoaded } from 'containers/BlockDetail/actions';
 
 import request from 'utils/request';
 
 export function* getBlock({ block }) {
-  const requestURL = `${API_URL_BASE}/transaction/block/${block}`;
-  
+  const requestURL = `${getLocationPath()}/transaction/block/${block}`;
+
   const result = yield call(request, requestURL);
-  
+
   yield put(blockLoaded(result));
 }
 

--- a/app/containers/BlockDetail/tests/saga.test.js
+++ b/app/containers/BlockDetail/tests/saga.test.js
@@ -10,6 +10,7 @@ import {
   API_URL_BASE,
   FIRST_BLOCK,
 } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { blockLoadingError, blockLoaded } from '../actions';
 
 import { LOAD_BLOCK } from '../constants';
@@ -37,7 +38,7 @@ describe('getBlock Saga', () => {
     };
 
     const saga = testSaga(getBlock, { block: FIRST_BLOCK });
-    const url = `${API_URL_BASE}/transaction/block/${FIRST_BLOCK}`;
+    const url = `${getLocationPath()}/transaction/block/${FIRST_BLOCK}`;
 
     saga
       .next()

--- a/app/containers/Blocks/index.jsx
+++ b/app/containers/Blocks/index.jsx
@@ -23,6 +23,7 @@ import { useInjectSaga } from 'utils/injectSaga';
 import sagaBlocks from 'containers/Blocks/saga';
 import { FIRST_BLOCK } from 'containers/App/constants';
 import { Col, Row } from 'reactstrap';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import { makeSelectLocation } from 'containers/App/selectors';
 
@@ -60,8 +61,8 @@ export function Blocks(props) {
 
     const pathname =
       props.location.pathname.toLowerCase().indexOf('block') > -1
-        ? '/blocks/'
-        : '/';
+        ? `${getSufixURL()}/blocks/`
+        : `${getSufixURL()}/`;
     const hashLink = blockNum => `${pathname}${blockNum}`;
     const previousBlockSet = () => {
       let result;

--- a/app/containers/Blocks/saga.js
+++ b/app/containers/Blocks/saga.js
@@ -1,6 +1,7 @@
 import { call, put, select, take } from 'redux-saga/effects';
 import { LOAD_BLOCKS } from 'containers/Blocks/constants';
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import request from 'utils/request';
 import { blocksLoaded } from './actions';
 import { makeSelectBlocks } from './selectors';
@@ -9,7 +10,7 @@ export function* getBlocks({ block }) {
   const state = yield select(makeSelectBlocks());
   const currentBlock =
     block || (state.appendBlocks ? state.previousBlock || '' : '');
-  const requestURL = `${API_URL_BASE}/transaction/blocks/${currentBlock}`;
+  const requestURL = `${getLocationPath()}/transaction/blocks/${currentBlock}`;
 
   const blocks = yield call(request, requestURL);
   yield put(blocksLoaded(blocks));

--- a/app/containers/Blocks/tests/saga.test.js
+++ b/app/containers/Blocks/tests/saga.test.js
@@ -10,6 +10,7 @@ import {
   API_URL_BASE,
   FIRST_BLOCK,
 } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import { LOAD_BLOCKS } from '../constants';
 import { blocksLoadingError, blocksLoaded } from '../actions';
@@ -38,7 +39,7 @@ describe('getBlocks Saga', () => {
     };
 
     const saga = testSaga(getBlocks, { block: FIRST_BLOCK });
-    const url = `${API_URL_BASE}/transaction/blocks/${FIRST_BLOCK}`;
+    const url = `${getLocationPath()}/transaction/blocks/${FIRST_BLOCK}`;
 
     saga
       .next()

--- a/app/containers/CrowdsaleDetail/index.jsx
+++ b/app/containers/CrowdsaleDetail/index.jsx
@@ -28,6 +28,7 @@ import styled from 'styled-components';
 import { useInjectSaga } from 'utils/injectSaga';
 import { useInjectReducer } from 'utils/injectReducer';
 import getWarningMessage from 'utils/getWarningMessage';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { startDeepFetch } from 'components/Token/actions';
 import AssetInfo from 'components/AssetInfo';
 import { makeSelectProperties } from 'components/Token/selectors';
@@ -140,7 +141,7 @@ export function CrowdsaleDetail(props) {
     </div>
   );
 
-  const pathname = props.addr ? `/address/${props.addr}` : '';
+  const pathname = props.addr ? `${getSufixURL}/address/${props.addr}` : `${getSufixURL()}`;
   const hashLink = v => `${pathname}/${v}`;
   const getItemKey = (item, idx) => item.txid.slice(0, 22).concat(idx);
 

--- a/app/containers/CrowdsaleDetail/saga.js
+++ b/app/containers/CrowdsaleDetail/saga.js
@@ -3,12 +3,13 @@ import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { LOAD_CROWDSALE_TRANSACTIONS } from './constants';
 import { updateCrowdsaleTransactionsFetch } from './actions';
 import makeSelectCrowdsaleDetail from './selectors';
 
 export function* getCrowdsaleTransactions({ start = 0, count = 10, id }) {
-  const requestURL = `${API_URL_BASE}/properties/gethistory/${id}`;
+  const requestURL = `${getLocationPath()}/properties/gethistory/${id}`;
   const state = yield select(makeSelectCrowdsaleDetail());
   const startPage = state.currentPage || start;
 

--- a/app/containers/CrowdsaleDetail/tests/saga.test.js
+++ b/app/containers/CrowdsaleDetail/tests/saga.test.js
@@ -8,6 +8,7 @@ import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 
 import { API_URL_BASE, ECOSYSTEM_PROD } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import {
   errorCrowdsaleTransactionsFetch,
   updateCrowdsaleTransactionsFetch,
@@ -51,7 +52,7 @@ describe('getCrowdsaleTransactions Saga', () => {
       start: startPage,
       count: 1000,
     });
-    const url = `${API_URL_BASE}/properties/gethistory/${id}`;
+    const url = `${getLocationPath()}/properties/gethistory/${id}`;
     const body = encoderURIParams(
       {
         startPage,

--- a/app/containers/Crowdsales/saga.js
+++ b/app/containers/Crowdsales/saga.js
@@ -3,12 +3,13 @@ import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { LOAD_CROWDSALES } from './constants';
 import { crowdsalesLoaded } from './actions';
 
 export function* getCrowdsales({ ecosystem }) {
-  const requestURL = `${API_URL_BASE}/properties/listactivecrowdsales`;
-  
+  const requestURL = `${getLocationPath()}/properties/listactivecrowdsales`;
+
   const body = encoderURIParams({ ecosystem });
   const options = {
     method: 'POST',
@@ -17,7 +18,7 @@ export function* getCrowdsales({ ecosystem }) {
     },
     body,
   };
-  
+
   const crowdsales = yield call(request, requestURL, options);
   yield put(crowdsalesLoaded(crowdsales));
 }

--- a/app/containers/Crowdsales/tests/saga.test.js
+++ b/app/containers/Crowdsales/tests/saga.test.js
@@ -8,6 +8,7 @@ import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 
 import { API_URL_BASE, ECOSYSTEM_PROD } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import {
   crowdsalesLoaded,
   crowdsalesLoadingError,
@@ -62,7 +63,7 @@ describe('getCrowdsales Saga', () => {
 
     const ecosystem = ECOSYSTEM_PROD;
     const saga = testSaga(getCrowdsales, { ecosystem });
-    const url = `${API_URL_BASE}/properties/listactivecrowdsales`;
+    const url = `${getLocationPath()}/properties/listactivecrowdsales`;
 
     const body = encoderURIParams({ ecosystem });
 

--- a/app/containers/Search/index.jsx
+++ b/app/containers/Search/index.jsx
@@ -24,6 +24,7 @@ import Asset from 'components/Asset';
 import LoadingIndicator from 'components/LoadingIndicator';
 import ContainerBase from 'components/ContainerBase';
 import StyledLink from 'components/StyledLink';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import { loadActivations } from 'containers/Activations/actions';
 import { makeSelectActivations } from 'containers/Activations/selectors';
@@ -123,7 +124,7 @@ export function Search(props) {
         <div className="container-fluid">
           <StyledLink
             to={{
-              pathname: `/address/${query}`,
+              pathname: `${getSufixURL()}/address/${query}`,
               state: { state: props.state },
             }}
           >

--- a/app/containers/Search/saga.js
+++ b/app/containers/Search/saga.js
@@ -9,11 +9,12 @@ import {
   API_URL_BLOCKCHAIN_BTC_BALANCE,
   FN_API_URL_BLOCKCHAIR_BTC_BALANCE,
 } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { LOAD_SEARCH } from './constants';
 import { searchLoaded } from './actions';
 
 export function* getSearch({ query }) {
-  const requestURL = `${API_URL_BASE}/search`;
+  const requestURL = `${getLocationPath()}/search`;
 
   const body = encoderURIParams({ query });
   const options = {

--- a/app/containers/Search/tests/saga.test.js
+++ b/app/containers/Search/tests/saga.test.js
@@ -8,6 +8,7 @@ import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { searchLoaded, searchLoadingError } from 'containers/Search/actions';
 import { LOAD_SEARCH } from 'containers/Search/constants';
 import root, { getSearch } from 'containers/Search/saga';
@@ -53,7 +54,7 @@ describe('getSearch Saga', () => {
     };
 
     const saga = testSaga(getSearch, { query: 'OMNI' });
-    const url = `${API_URL_BASE}/search`;
+    const url = `${getLocationPath()}/search`;
     const body = encoderURIParams({ query: 'OMNI' });
 
     const options = {

--- a/app/containers/TransactionDetail/saga.js
+++ b/app/containers/TransactionDetail/saga.js
@@ -1,13 +1,14 @@
 import { all, call, put, take, takeLatest } from 'redux-saga/effects';
 import { LOAD_TRANSACTION } from 'containers/TransactionDetail/constants';
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { transactionLoaded } from 'containers/TransactionDetail/actions';
 
 import request from 'utils/request';
 
 export function* getTransaction(action = {}) {
   const txid = action.tx;
-  const requestURL = `${API_URL_BASE}/transaction/tx/${txid}`;
+  const requestURL = `${getLocationPath()}/transaction/tx/${txid}`;
 
   const tx = yield call(request, requestURL);
   yield put(transactionLoaded(tx));

--- a/app/containers/TransactionDetail/tests/saga.test.js
+++ b/app/containers/TransactionDetail/tests/saga.test.js
@@ -7,6 +7,7 @@ import { testSaga } from 'redux-saga-test-plan';
 
 import request from 'utils/request';
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import { LOAD_TRANSACTION, LOAD_TRANSACTION_SUCCESS } from '../constants';
 import { transactionLoadingError } from '../actions';
 
@@ -49,7 +50,7 @@ describe('getTransaction Saga', () => {
     };
 
     const saga = testSaga(getTransaction, { tx: txid });
-    const url = `${API_URL_BASE}/transaction/tx/${txid}`;
+    const url = `${getLocationPath()}/transaction/tx/${txid}`;
 
     saga
       .next()

--- a/app/containers/Transactions/index.jsx
+++ b/app/containers/Transactions/index.jsx
@@ -13,6 +13,7 @@ import { compose } from 'redux';
 import List from 'components/List';
 import TransactionListHeader from 'components/TransactionListHeader';
 import Transaction from 'components/Transaction';
+import ExodusTransaction from 'components/ExodusTransaction';
 import ContainerBase from 'components/ContainerBase';
 import LoadingIndicator from 'components/LoadingIndicator';
 import NoOmniTransactions from 'components/NoOmniTransactions';
@@ -21,6 +22,7 @@ import FooterLinks from 'components/FooterLinks';
 import { useInjectReducer } from 'utils/injectReducer';
 import { useInjectSaga } from 'utils/injectSaga';
 import history from 'utils/history';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 
 import { Button, ButtonGroup } from 'reactstrap';
 import getMaxPagesByMedia from 'utils/getMaxPagesByMedia';
@@ -117,7 +119,7 @@ export function Transactions(props) {
     props.setCurrentPage(page);
   };
 
-  const pathname = props.addr ? `/address/${props.addr}` : '';
+  const pathname = props.addr ? `${getSufixURL()}/address/${props.addr}` : `${getSufixURL()}`;
   const hashLink = v => `${pathname}/${v}`;
   // const loadTxs = confirmed =>
   //   (confirmed ? props.loadTransactions : props.loadUnconfirmed)(props.addr);
@@ -160,7 +162,7 @@ export function Transactions(props) {
     const _props = {
       ...props.transactions,
       addr,
-      inner: Transaction,
+      inner: exodusTxs ? ExodusTransaction : Transaction,
       onSetPage: props.unconfirmed
         ? unconfirmedHandlePageClick
         : handlePageClick,

--- a/app/containers/Transactions/saga.js
+++ b/app/containers/Transactions/saga.js
@@ -1,6 +1,7 @@
 import { all, call, put, select, take } from 'redux-saga/effects';
 import { LOAD_TRANSACTIONS, LOAD_UNCONFIRMED, LOAD_EXODUS_TXS, SET_TRANSACTION_TYPE } from 'containers/Transactions/constants';
 import { API_URL_BASE, FN_API_URL_BLOCKCHAIN_ADDR } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import request from 'utils/request';
 import encoderURIParams from 'utils/encoderURIParams';
 import getMaxPagesByMedia from 'utils/getMaxPagesByMedia';
@@ -9,8 +10,8 @@ import { makeSelectTransactions } from './selectors';
 
 export function* getUnconfirmed({ addr }) {
   const requestURL = addr
-    ? `${API_URL_BASE}/transaction/unconfirmed/${addr}`
-    : `${API_URL_BASE}/transaction/unconfirmed`;
+    ? `${getLocationPath()}/transaction/unconfirmed/${addr}`
+    : `${getLocationPath()}/transaction/unconfirmed`;
 
   const transactions = yield call(request, requestURL);
   yield put(transactionsLoaded(transactions.data, 1));
@@ -37,8 +38,8 @@ export function* getTransactions({ addr }) {
   const { txType } = state;
 
   const requestURL = addr
-    ? `${API_URL_BASE}/transaction/address/${page}`
-    : `${API_URL_BASE}/transaction/general/${page}`;
+    ? `${getLocationPath()}/transaction/address/${page}`
+    : `${getLocationPath()}/transaction/general/${page}`;
 
   const getTransactionsOptions = {
     type: 'cors',

--- a/app/containers/Transactions/tests/saga.test.js
+++ b/app/containers/Transactions/tests/saga.test.js
@@ -7,6 +7,7 @@ import { testSaga } from 'redux-saga-test-plan';
 import request from 'utils/request';
 
 import { API_URL_BASE } from 'containers/App/constants';
+import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
 import {
   LOAD_TRANSACTIONS,
   SET_TRANSACTION_TYPE,
@@ -58,7 +59,7 @@ describe('getTransaction Saga', () => {
     };
 
     const saga = testSaga(getTransactions, { tx: txid });
-    const url = `${API_URL_BASE}/transaction/general/0`;
+    const url = `${getLocationPath()}/transaction/general/0`;
     const getTransactionsOptions = {
       type: 'cors',
       method: 'POST',

--- a/app/utils/getLocationPath.js
+++ b/app/utils/getLocationPath.js
@@ -1,0 +1,10 @@
+import { API_TESTNET_URL_BASE, API_URL_BASE } from 'containers/App/constants';
+
+export default () => {
+  const isTestnet = window.location.href.includes('testnet');
+
+  return isTestnet ? API_TESTNET_URL_BASE : API_URL_BASE;
+};
+
+export const getSufixURL = () =>
+  window.location.href.includes('testnet') ? '/testnet' : '';

--- a/app/utils/searchInDOM.js
+++ b/app/utils/searchInDOM.js
@@ -1,0 +1,13 @@
+export default (query) => (function (query) {
+  const docWidth = document.documentElement.offsetWidth;
+  [].forEach.call(
+    document.querySelectorAll('*'),
+
+    function (el) {
+      if (el.offsetWidth > docWidth) {
+        el.style.outline = query;
+        console.log(el);
+      }
+    },
+  );
+})(query); // query= '1px solid red'


### PR DESCRIPTION
### Changes

+ added support to explore testnet environment :partying_face::partying_face::partying_face:
+ added helper functions `getLocationPath` and `getSufixURL` to resolve basepath for `[prod|testnet]` environments
+ #refactoring: use of `getLocationPath` in redux-sagas URLs to resolve `[prod|testnet]` environments
+ #refactoring: use of `getSufixURL` in explorer URLs to resolve  `[prod|testnet]` environments