### PR TITLE
Fix txdetail without propid

### DIFF
--- a/app/components/Token/saga.js
+++ b/app/components/Token/saga.js
@@ -16,7 +16,13 @@ function* fetchSingleProperty(action) {
 
   const state = yield select(st => st);
   const { tokens } = state.token;
-  let requestedProp = tokens[action.id.toString()];
+
+  let requestedProp;
+  if(action.id){
+    requestedProp = tokens[action.id.toString()];
+  } else {
+    throw new Error(`The property hasn't got an Id`);
+  }
 
   if (action.id && (!requestedProp || !requestedProp.isFetching)) {
     yield put({ type: FETCHING_PROPERTY, propertyId: action.id });

--- a/app/components/TransactionInfo/index.jsx
+++ b/app/components/TransactionInfo/index.jsx
@@ -13,7 +13,16 @@ import styled from 'styled-components';
 import { FormattedUnixDateTime } from 'components/FormattedDateTime';
 import StyledLink from 'components/StyledLink';
 import StyledA from 'components/StyledA';
-import { Card, CardBody, CardHeader, CardText, Col, Collapse, Row, Table } from 'reactstrap';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardText,
+  Col,
+  Collapse,
+  Row,
+  Table,
+} from 'reactstrap';
 
 import TransactionAmount from 'components/TransactionAmount';
 import SanitizedFormattedNumber from 'components/SanitizedFormattedNumber';
@@ -25,8 +34,8 @@ import ExplorerLink from 'components/ExplorerLink';
 import { EXTERNAL_EXPLORER_BLOCKCHAIR } from 'components/ExplorerLink/constants';
 
 import { CONFIRMATIONS } from 'containers/Transactions/constants';
-import { API_URL_BASE, FEATURE_ACTIVATION_TYPE_INT } from 'containers/App/constants';
-import getLocationPath, {getSufixURL} from 'utils/getLocationPath';
+import { FEATURE_ACTIVATION_TYPE_INT } from 'containers/App/constants';
+import { getSufixURL } from 'utils/getLocationPath';
 import getTransactionHeading from 'utils/getTransactionHeading';
 
 const StyledCard = styled(Card)`
@@ -57,15 +66,17 @@ function TransactionInfo(props) {
   const statusColor = props.valid
     ? 'btn btn-group btn-primary btn-block btn-blue font-weight-light'
     : props.confirmations === 0
-      ? 'btn btn-group btn-primary btn-block btn-warning font-weight-light'
-      : 'btn btn-group btn-primary btn-block btn-danger font-weight-light';
+    ? 'btn btn-group btn-primary btn-block btn-warning font-weight-light'
+    : 'btn btn-group btn-primary btn-block btn-danger font-weight-light';
 
   const status = StatusConfirmation({
     ...props,
     confirmed: CONFIRMATIONS,
   });
   const invalidReason =
-    props.confirmations === 0 ? '' : `Reason: ${props.invalidreason || 'invalid transaction'}`;
+    props.confirmations === 0
+      ? ''
+      : `Reason: ${props.invalidreason || 'invalid transaction'}`;
   const rawTransactionURL = `${getSufixURL()}/transaction/tx/${props.txid}`;
 
   let warningMessage = null;
@@ -122,8 +133,7 @@ function TransactionInfo(props) {
       </tr>
     );
   }
-
-  if(props.type_int === FEATURE_ACTIVATION_TYPE_INT){
+  if (props.type_int === FEATURE_ACTIVATION_TYPE_INT) {
     tokenName = (
       <tr>
         <td className="field">Feature Activation</td>
@@ -142,8 +152,18 @@ function TransactionInfo(props) {
       </tr>
     );
   }
-  if (!props.valid && ([50, 51, 54].includes(props.type_int) || !props.type_int)) {
-    tokenName = null;
+  if (
+    !props.valid &&
+    ([50, 51, 54].includes(props.type_int) || !props.type_int)
+  ) {
+    tokenName = props.propertyname ? (
+      <tr>
+        <td className="field">Property</td>
+        <td>
+          <strong>{props.propertyname}</strong>
+        </td>
+      </tr>
+    ) : null;
   }
 
   let btcDesired;
@@ -155,7 +175,7 @@ function TransactionInfo(props) {
         <td>
           <strong>
             <span id="lamount">
-              <SanitizedFormattedNumber value={props.bitcoindesired}/> BTC
+              <SanitizedFormattedNumber value={props.bitcoindesired} /> BTC
             </span>
           </strong>
         </td>
@@ -164,7 +184,8 @@ function TransactionInfo(props) {
     specificAction = `- ${props.action}`;
   }
 
-  const recipient = props.referenceaddress || (props.purchases || [{}])[0].referenceaddress;
+  const recipient =
+    props.referenceaddress || (props.purchases || [{}])[0].referenceaddress;
 
   return (
     <div>
@@ -173,173 +194,179 @@ function TransactionInfo(props) {
         <Col sm>
           <Table responsive>
             <thead>
-            <tr>
-              <th>
-                <AssetLink asset={props.asset.propertyid} state={props.state}>
-                  <AssetLogo
-                    asset={props.asset}
-                    prop={props.asset.propertyid}
-                    className="img-thumbnail"
-                    style={{
-                      width: '4rem',
-                      height: '4rem',
-                    }}
-                  />
-                </AssetLink>
-              </th>
-              <th>
-                <h4>
-                  {getTransactionHeading(props)} {specificAction}
-                  <SubtitleDetail>{props.txid}</SubtitleDetail>
-                </h4>
-              </th>
-            </tr>
+              <tr>
+                <th>
+                  <AssetLink asset={props.asset.propertyid} state={props.state}>
+                    <AssetLogo
+                      asset={props.asset}
+                      prop={props.asset.propertyid}
+                      className="img-thumbnail"
+                      style={{
+                        width: '4rem',
+                        height: '4rem',
+                      }}
+                    />
+                  </AssetLink>
+                </th>
+                <th>
+                  <h4>
+                    {getTransactionHeading(props)} {specificAction}
+                    <SubtitleDetail>{props.txid}</SubtitleDetail>
+                  </h4>
+                </th>
+              </tr>
             </thead>
             <tbody>
-            {amountDisplay}
-            {tokenName}
-            {activationBlock}
-            {btcDesired}
-            <tr>
-              <td className="field">Sender</td>
-              <td>
-                <StyledLink
-                  to={{
-                    pathname: `${getSufixURL()}/address/${props.sendingaddress}`,
-                    state: { state: props.state },
-                  }}
-                >
-                  {props.sendingaddress}
-                </StyledLink>
-              </td>
-            </tr>
-            {recipient &&
-            <tr>
-              <td className="field">Recipient</td>
-              <td>
-                <StyledLink
-                  to={{
-                    pathname: `${getSufixURL()}/address/${recipient}`,
-                    state: { state: props.state },
-                  }}
-                >
-                  {recipient}
-                </StyledLink>
-              </td>
-            </tr>
-            }
-            <tr>
-              <td className="field">{dtheader}</td>
-              <td>
+              {amountDisplay}
+              {tokenName}
+              {activationBlock}
+              {btcDesired}
+              <tr>
+                <td className="field">Sender</td>
+                <td>
+                  <StyledLink
+                    to={{
+                      pathname: `${getSufixURL()}/address/${props.sendingaddress}`,
+                      state: { state: props.state },
+                    }}
+                  >
+                    {props.sendingaddress}
+                  </StyledLink>
+                </td>
+              </tr>
+              {recipient &&
+                <tr>
+                  <td className="field">Recipient</td>
+                  <td>
+                    <StyledLink
+                      to={{
+                        pathname: `${getSufixURL()}/address/${recipient}`,
+                        state: { state: props.state },
+                      }}
+                    >
+                      {recipient}
+                    </StyledLink>
+                  </td>
+                </tr>
+              )}
+              <tr>
+                <td className="field">{dtheader}</td>
+                <td>
                   <span id="ldatetime">
-                    <FormattedUnixDateTime datetime={props.blocktime}/>
+                    <FormattedUnixDateTime datetime={props.blocktime} />
                   </span>
-              </td>
-            </tr>
-            {props.block &&
-            <tr>
-              <td className="field">In Block</td>
-              <td>
-                <StyledLink
-                  to={{
-                    pathname: `${getSufixURL()}/block/${props.block}`,
-                    state: { state: props.state },
-                  }}
-                >
-                  <span id="lblocknum">{props.block}</span>
-                </StyledLink>
-              </td>
-            </tr>
-            }
-            <tr>
-              <td className="field" style={{ paddingTop: '12px' }}>
-                Status
-              </td>
-              <td className="field">
-                <div className={statusColor} style={{ width: '35%', cursor: 'default' }}>
-                  {status}
-                </div>
-                <div className="text-left">{!props.valid && invalidReason}</div>
-              </td>
-            </tr>
-            <tr>
-              <td className="field">Bitcoin Fees</td>
-              <td>
-                <span id="lfees">{props.fee} BTC</span>
-              </td>
-            </tr>
-            <tr>
-              <td className="field">Omni Layer Fees</td>
-              <td>
-                <span id="lomnifees">0.00 OMNI</span>
-              </td>
-            </tr>
-            <tr className="d-none">
-              <td className="field">Payload</td>
-              <td>
-                <span id="lpayloadsize">16</span> bytes
-              </td>
-            </tr>
-            <tr className="d-none">
-              <td className="field">Size</td>
-              <td>
-                <span id="ltxsize">N/A</span>
-              </td>
-            </tr>
-            <tr className="d-none">
-              <td className="field">Class</td>
-              <td>
-                <span id="lclass">C (nulldata)</span>
-              </td>
-            </tr>
-            <tr>
-              <td className="field">Type/Version</td>
-              <td>
+                </td>
+              </tr>
+              {props.block &&
+                <tr>
+                  <td className="field">In Block</td>
+                  <td>
+                    <StyledLink
+                      to={{
+                        pathname: `${getSufixURL()}/block/${props.block}`,
+                        state: { state: props.state },
+                      }}
+                    >
+                      <span id="lblocknum">{props.block}</span>
+                    </StyledLink>
+                  </td>
+                </tr>
+              )}
+              <tr>
+                <td className="field" style={{ paddingTop: '12px' }}>
+                  Status
+                </td>
+                <td className="field">
+                  <div
+className={statusColor} style={{
+                      width: '35%',
+                    cursor: 'default',
+                  }}>
+                    {status}
+                  </div>
+                  <div className="text-left">{!props.valid && invalidReason}</div>
+                </td>
+              </tr>
+              <tr>
+                <td className="field">Bitcoin Fees</td>
+                <td>
+                  <span id="lfees">{props.fee} BTC</span>
+                </td>
+              </tr>
+              <tr>
+                <td className="field">Omni Layer Fees</td>
+                <td>
+                  <span id="lomnifees">0.00 OMNI</span>
+                </td>
+              </tr>
+              <tr className="d-none">
+                <td className="field">Payload</td>
+                <td>
+                  <span id="lpayloadsize">16</span> bytes
+                </td>
+              </tr>
+              <tr className="d-none">
+                <td className="field">Size</td>
+                <td>
+                  <span id="ltxsize">N/A</span>
+                </td>
+              </tr>
+              <tr className="d-none">
+                <td className="field">Class</td>
+                <td>
+                  <span id="lclass">C (nulldata)</span>
+                </td>
+              </tr>
+              <tr>
+                <td className="field">Type/Version</td>
+                <td>
                   <span id="ltypever">
                     Type {props.type_int}, Version {props.version}
                   </span>
-              </td>
-            </tr>
-            <tr>
-              <td className="field">Raw Data</td>
-              <td>
+                </td>
+              </tr>
+              <tr>
+                <td className="field">Raw Data</td>
+                <td>
                   <span id="lrawgettx">
                     <StyledA href={rawTransactionURL} target="_blank">
                       Click here for raw transaction...
                     </StyledA>
                   </span>
-              </td>
-            </tr>
-            <tr>
-              <td className="field">Other explorers</td>
-              <td>
-                  <ExplorerLink className="d-inline-block mr-3" explorerId={EXTERNAL_EXPLORER_BLOCKCHAIR} tx={props.txid} />
-              </td>
-            </tr>
-            <tr className="d-none">
-              <td colSpan="2">
-                <StyledA
-                  href="#collapseRawData"
-                  color="primary"
-                  onClick={toggleDecoded}
-                  style={{ marginBottom: '1rem' }}
-                >
-                  Decoded Raw Payload
-                </StyledA>
-                <Collapse isOpen={collapseDecoded}>
+                </td>
+              </tr>
+              <tr>
+                <td className="field">Other explorers</td>
+                <td>
+                  <ExplorerLink
+className="d-inline-block mr-3" explorerId={EXTERNAL_EXPLORER_BLOCKCHAIR}
+                    tx={props.txid} />
+                </td>
+              </tr>
+              <tr className="d-none">
+                <td colSpan="2">
+                  <StyledA
+                    href="#collapseRawData"
+                    color="primary"
+                    onClick={toggleDecoded}
+                    style={{ marginBottom: '1rem' }}
+                  >
+                    Decoded Raw Payload
+                  </StyledA>
+                  <Collapse isOpen={collapseDecoded}>
                     <span id="lrawgettx">
                       <StyledA href="/rawpayload">
                         (Coming Soon) Click here for raw payload...
                       </StyledA>
                     </span>
-                </Collapse>
-              </td>
-            </tr>
+                  </Collapse>
+                </td>
+              </tr>
             </tbody>
           </Table>
         </Col>
       </DetailRow>
-      <Row/>
+      <Row />
     </div>
   );
 }

--- a/app/components/TransactionInfo/index.jsx
+++ b/app/components/TransactionInfo/index.jsx
@@ -34,8 +34,11 @@ import ExplorerLink from 'components/ExplorerLink';
 import { EXTERNAL_EXPLORER_BLOCKCHAIR } from 'components/ExplorerLink/constants';
 
 import { CONFIRMATIONS } from 'containers/Transactions/constants';
-import { FEATURE_ACTIVATION_TYPE_INT } from 'containers/App/constants';
-import { getSufixURL } from 'utils/getLocationPath';
+import {
+  API_URL_BASE,
+  FEATURE_ACTIVATION_TYPE_INT,
+} from 'containers/App/constants';
+import getLocationPath, { getSufixURL } from 'utils/getLocationPath';
 import getTransactionHeading from 'utils/getTransactionHeading';
 
 const StyledCard = styled(Card)`
@@ -66,8 +69,8 @@ function TransactionInfo(props) {
   const statusColor = props.valid
     ? 'btn btn-group btn-primary btn-block btn-blue font-weight-light'
     : props.confirmations === 0
-    ? 'btn btn-group btn-primary btn-block btn-warning font-weight-light'
-    : 'btn btn-group btn-primary btn-block btn-danger font-weight-light';
+      ? 'btn btn-group btn-primary btn-block btn-warning font-weight-light'
+      : 'btn btn-group btn-primary btn-block btn-danger font-weight-light';
 
   const status = StatusConfirmation({
     ...props,
@@ -156,6 +159,7 @@ function TransactionInfo(props) {
     !props.valid &&
     ([50, 51, 54].includes(props.type_int) || !props.type_int)
   ) {
+    debugger;
     tokenName = props.propertyname ? (
       <tr>
         <td className="field">Property</td>
@@ -226,7 +230,9 @@ function TransactionInfo(props) {
                 <td>
                   <StyledLink
                     to={{
-                      pathname: `${getSufixURL()}/address/${props.sendingaddress}`,
+                      pathname: `${getSufixURL()}/address/${
+                        props.sendingaddress
+                      }`,
                       state: { state: props.state },
                     }}
                   >
@@ -234,7 +240,7 @@ function TransactionInfo(props) {
                   </StyledLink>
                 </td>
               </tr>
-              {recipient &&
+              {recipient && (
                 <tr>
                   <td className="field">Recipient</td>
                   <td>
@@ -257,7 +263,7 @@ function TransactionInfo(props) {
                   </span>
                 </td>
               </tr>
-              {props.block &&
+              {props.block && (
                 <tr>
                   <td className="field">In Block</td>
                   <td>
@@ -278,13 +284,14 @@ function TransactionInfo(props) {
                 </td>
                 <td className="field">
                   <div
-className={statusColor} style={{
-                      width: '35%',
-                    cursor: 'default',
-                  }}>
+                    className={statusColor}
+                    style={{ width: '35%', cursor: 'default' }}
+                  >
                     {status}
                   </div>
-                  <div className="text-left">{!props.valid && invalidReason}</div>
+                  <div className="text-left">
+                    {!props.valid && invalidReason}
+                  </div>
                 </td>
               </tr>
               <tr>
@@ -339,8 +346,10 @@ className={statusColor} style={{
                 <td className="field">Other explorers</td>
                 <td>
                   <ExplorerLink
-className="d-inline-block mr-3" explorerId={EXTERNAL_EXPLORER_BLOCKCHAIR}
-                    tx={props.txid} />
+                    className="d-inline-block mr-3"
+                    explorerId={EXTERNAL_EXPLORER_BLOCKCHAIR}
+                    tx={props.txid}
+                  />
                 </td>
               </tr>
               <tr className="d-none">

--- a/app/containers/TransactionDetail/index.jsx
+++ b/app/containers/TransactionDetail/index.jsx
@@ -18,7 +18,7 @@ import getPropByTx from 'utils/getPropByTx';
 import LoadingIndicator from 'components/LoadingIndicator';
 import TransactionInfo from 'components/TransactionInfo';
 import ContainerBase from 'components/ContainerBase';
-import { startFetch } from 'components/Token/actions';
+import { startFetch, cancelFetch } from 'components/Token/actions';
 import { makeSelectProperties } from 'components/Token/selectors';
 import { loadActivations } from 'containers/Activations/actions';
 import { makeSelectActivations } from 'containers/Activations/selectors';
@@ -53,8 +53,10 @@ export function TransactionDetail(props) {
     ) {
       if (isActivation()) {
         props.loadActivations();
-      } else {
+      } else if (props.txdetail.transaction.propertyid){
         props.getProperty(props.txdetail.transaction.propertyid);
+      } else {
+        props.cancelFetch();
       }
     }
   }, [props.txdetail.loading]);
@@ -128,6 +130,7 @@ function mapDispatchToProps(dispatch) {
     dispatch,
     loadTransaction: (addr, page) => dispatch(loadTransaction(addr, page)),
     getProperty: propertyId => dispatch(startFetch(propertyId)),
+    cancelFetch: ()=>dispatch(cancelFetch()),
     loadActivations: () => dispatch(loadActivations()),
   };
 }

--- a/app/utils/getLogo.js
+++ b/app/utils/getLogo.js
@@ -15,9 +15,9 @@ export default (id, propertyinfo = {}) => {
         logo = require('images/tokenscam.png');
       } else if (flags.replaced) {
         logo = require('images/tokenreplaced.png');
-      } else if (flags.registered) {
+      } else if (flags.registered && id) {
         logo = require(`images/token${id}.png`);
-      } else if (flags.invalid) {
+      } else if (flags.invalid && id) {
         logo = require(`images/token${id}.png`);
       } else {
         logo = require('images/tokendefault.png');


### PR DESCRIPTION
### Changes

+ throw error if try to request token details without propertyid
+ cancel token fetch if there isn't propertyid
+ added token name for transactions with `typeid === 51`
+ verify there is a token id before to load the token logo
+ fix indentation