### PR TITLE
Hotfixes

### DIFF
--- a/app/components/ErrorBoundary/index.jsx
+++ b/app/components/ErrorBoundary/index.jsx
@@ -36,7 +36,7 @@ const RetryMessage = () => (
         <span>retry</span>
       </RetryLink>
     </BrowserRouter>
-    &nbsp; again in few moments.
+    again in few moments.
   </h5>
 );
 

--- a/app/components/Token/saga.js
+++ b/app/components/Token/saga.js
@@ -134,7 +134,7 @@ function* fetchManyProperties(action) {
       },
       body,
     });
-    const propChunks = chunk(action.properties.map(token => token.id), 30);
+    const propChunks = chunk(action.properties, 30);
     const encodedChunks = propChunks.map(propChunk =>
       encoderURIParams({ prop_ids: propChunk.map(id => id) }),
     );

--- a/app/components/Token/selectors.js
+++ b/app/components/Token/selectors.js
@@ -22,13 +22,13 @@ const makeSelectProperties = () =>
     substate => substate.tokens,
   );
 
-const makeSelectProperty = id =>
+const makeSelectProperty = state => id =>
   createSelector(
-    [selectTokenDomain],
-    (substate, id) => substate.tokens[id],
+    selectTokenDomain,
+    substate => substate.tokens[id],
   );
 
-const makeSelectLoading = () =>
+const makeSelectLoadingTokens = () =>
   createSelector(
     selectTokenDomain,
     substate => substate.isFetching,
@@ -40,7 +40,7 @@ const makeSelectLastFetched = () =>
     substate => substate.lastFetched,
   );
 
-const makeSelectHasProperty = id =>
+const makeSelectHasProperty = state => id =>
   createSelector(
     selectTokenDomain,
     substate => !!substate.tokens[id],
@@ -50,7 +50,7 @@ export {
   selectTokenDomain,
   makeSelectProperties,
   makeSelectProperty,
-  makeSelectLoading,
+  makeSelectLoadingTokens,
   makeSelectHasProperty,
   makeSelectLastFetched,
 };

--- a/app/components/Wallet/index.jsx
+++ b/app/components/Wallet/index.jsx
@@ -29,7 +29,7 @@ import { startFetchMany } from 'components/Token/actions';
 import {
   makeSelectHasProperty,
   makeSelectLastFetched,
-  makeSelectLoading,
+  makeSelectLoadingTokens,
   makeSelectProperties,
 } from 'components/Token/selectors';
 import LoadingIndicator from 'components/LoadingIndicator';
@@ -271,7 +271,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = createStructuredSelector({
   tokens: makeSelectProperties(),
-  loadingTokens: makeSelectLoading(),
+  loadingTokens: makeSelectLoadingTokens(),
   lastFetched: makeSelectLastFetched(),
   hasPropertyFetched: makeSelectHasProperty,
 });

--- a/app/containers/AssetDetail/index.jsx
+++ b/app/containers/AssetDetail/index.jsx
@@ -14,7 +14,7 @@ import StyledLink from 'components/StyledLink';
 import { Col, Row, Table } from 'reactstrap';
 
 import { startFetch } from 'components/Token/actions';
-import { makeSelectLoading, makeSelectProperties } from 'components/Token/selectors';
+import { makeSelectLoadingTokens, makeSelectProperties } from 'components/Token/selectors';
 import AssetInfo from 'components/AssetInfo';
 import LoadingIndicator from 'components/LoadingIndicator';
 import ContainerBase from 'components/ContainerBase';
@@ -122,7 +122,7 @@ AssetDetail.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  loading: makeSelectLoading(),
+  loading: makeSelectLoadingTokens(),
   tokens: makeSelectProperties(),
 });
 

--- a/app/containers/Transactions/index.jsx
+++ b/app/containers/Transactions/index.jsx
@@ -212,7 +212,7 @@ export function Transactions(props) {
       usePagination,
     };
 
-    const mergePropertyFlags = property => (property.propertyid ? {...property, flags: props.tokens[property.propertyid].flags} : property)
+    const mergePropertyFlags = property => (property.propertyid ? {...property, flags: (props.tokens[property.propertyid] || {flags:{}}).flags} : property);
     _props.items = getCurrentData(props.transactions.currentPage).map(x => mergePropertyFlags(x));
     content = <List {..._props} />;
   }

--- a/app/containers/Transactions/index.jsx
+++ b/app/containers/Transactions/index.jsx
@@ -122,16 +122,12 @@ export function Transactions(props) {
       transactions.length > maxResults
         ? ((page || currentPage()) - 1) * maxResults
         : 0;
-    // ? ((page || pageParam) - 1) * maxPagesByMedia
 
-    // const end =
-    //   transactions.length > maxPagesByMedia
-    //     ? ((page || pageParam) - 1) * maxPagesByMedia + maxPagesByMedia
-    //     : maxPagesByMedia;
     const end =
       transactions.length > maxResults
         ? ((page || currentPage()) - 1) * maxResults + maxResults
         : maxResults;
+    
     return transactions.slice(start, end);
   };
   const getTransactions = () => props.transactions.transactions;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniexplorer",
-  "version": "5.0.3",
+  "version": "5.0.7",
   "description": "Omni Explorer is a Block Explorer and Analytics Platform for the Omni Layer",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Fixes

+ #fix show Dup/Scam icons on class A/B txs
+ #fix retry message spacing
+ #fix Token selectors parameters
+ refactoring Token saga `fetchManyProperties` to receive an array of props id
+ renamed Token selector `makeSelectLoading` to `makeSelectLoadingTokens`
+ prevent error if property flags is undefined
+ update "version" => "5.0.7"